### PR TITLE
Refactor Media3 bindings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,9 @@
 <Project>
+  <PropertyGroup Condition="'$(MSBuildProjectDirectory.Contains(media3))' == 'false'">
+      <!-- Opt out of C#8 features to maintain compatibility with legacy -->
+      <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>
+      <AndroidBoundInterfacesContainTypes>false</AndroidBoundInterfacesContainTypes>
+    </PropertyGroup>
   <PropertyGroup>
     <RepositoryUrl>https://github.com/xamarin/AndroidX.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -11,10 +16,6 @@
     
     <!-- Enable DIM/SIM for Classic (defaults to true on .NET) -->
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
-
-    <!-- Opt out of C#8 features to maintain compatibility with legacy -->
-    <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>
-    <AndroidBoundInterfacesContainTypes>false</AndroidBoundInterfacesContainTypes>
 
     <!-- .NET 6+ generates Resource.designer.cs files for bindings projects which we do not want -->
     <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>

--- a/source/androidx.media3/media3-datasource-cronet/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-datasource-cronet/Transforms/Metadata.xml
@@ -16,7 +16,7 @@
         path="/api/package[@name='androidx.media3.datasource.cronet']/class[@name='CronetDataSource.Factory']/method[@name='setDefaultRequestProperties' and count(parameter)=1 and parameter[1][@type='java.util.Map&lt;java.lang.String, java.lang.String&gt;']]"
         name="managedReturn"
         >
-        AndroidX.Media3.DataSource.IHttpDataSourceFactory
+        AndroidX.Media3.DataSource.IHttpDataSource.IFactory
     </attr>
 
     <attr

--- a/source/androidx.media3/media3-datasource-okhttp/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-datasource-okhttp/Transforms/Metadata.xml
@@ -9,7 +9,7 @@
         path="/api/package[@name='androidx.media3.datasource.okhttp']/class[@name='OkHttpDataSource.Factory']/method[@name='setDefaultRequestProperties' and count(parameter)=1 and parameter[1][@type='java.util.Map&lt;java.lang.String, java.lang.String&gt;']]"
         name="managedReturn"
         >
-        AndroidX.Media3.DataSource.IHttpDataSourceFactory
+        AndroidX.Media3.DataSource.IHttpDataSource.IFactory
     </attr>
 
 </metadata>

--- a/source/androidx.media3/media3-datasource/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-datasource/Transforms/Metadata.xml
@@ -27,7 +27,7 @@
         path="/api/package[@name='androidx.media3.datasource']/class[@name='DefaultHttpDataSource.Factory']/method[@name='setDefaultRequestProperties' and count(parameter)=1 and parameter[1][@type='java.util.Map&lt;java.lang.String, java.lang.String&gt;']]"
         name="managedReturn"
           >
-      AndroidX.Media3.DataSource.IHttpDataSourceFactory
+      AndroidX.Media3.DataSource.IHttpDataSource.IFactory
     </attr>
     <attr
         path="/api/package[@name='androidx.media3.datasource']/class[@name='DefaultHttpDataSource.Factory']/method[@name='createDataSource' and count(parameter)=0]"

--- a/source/androidx.media3/media3-effect/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-effect/Transforms/Metadata.xml
@@ -138,7 +138,6 @@
         AndroidX.Media3.Common.IVideoFrameProcessor
     </attr>
 
-
     <attr
         path="/api/package[@name='androidx.media3.effect']/class[@name='DefaultVideoFrameProcessor.Factory']/method[@name='create' and count(parameter)=6 and parameter[1][@type='android.content.Context'] and parameter[2][@type='androidx.media3.common.DebugViewProvider'] and parameter[3][@type='androidx.media3.common.ColorInfo'] and parameter[4][@type='boolean'] and parameter[5][@type='java.util.concurrent.Executor'] and parameter[6][@type='androidx.media3.common.VideoFrameProcessor.Listener']]"
         name="managedReturn"
@@ -146,5 +145,11 @@
         AndroidX.Media3.Common.IVideoFrameProcessor
     </attr>
 
-
+    <!-- Remove this for now as I cant figure this one out, something to do with the event not having the correct parameter, probably because two events need to exist.-->
+    <remove-node
+        path="/api/package[@name='androidx.media3.effect']/interface[@name='VideoCompositor.Listener']/method[@name='onEnded' and count(parameter)=0]"
+        />
+    <remove-node
+        path="/api/package[@name='androidx.media3.effect']/interface[@name='VideoCompositor.Listener']/method[@name='onError' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.VideoFrameProcessingException']]"
+        />
 </metadata>

--- a/source/androidx.media3/media3-exoplayer-dash/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-exoplayer-dash/Transforms/Metadata.xml
@@ -41,4 +41,23 @@
       true
     </attr>
 
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.dash']/class[@name='DashMediaSource.Factory']/method[@name='createMediaSource' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.dash']/class[@name='DashMediaSource.Factory']/method[@name='setDrmSessionManagerProvider' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.drm.DrmSessionManagerProvider']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.dash']/class[@name='DashMediaSource.Factory']/method[@name='setLoadErrorHandlingPolicy' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+
 </metadata>

--- a/source/androidx.media3/media3-exoplayer-hls/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-exoplayer-hls/Transforms/Metadata.xml
@@ -88,4 +88,23 @@
       true
     </attr>
 
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.hls']/class[@name='HlsMediaSource.Factory']/method[@name='createMediaSource' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.hls']/class[@name='HlsMediaSource.Factory']/method[@name='setDrmSessionManagerProvider' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.drm.DrmSessionManagerProvider']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.hls']/class[@name='HlsMediaSource.Factory']/method[@name='setLoadErrorHandlingPolicy' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+
 </metadata>

--- a/source/androidx.media3/media3-exoplayer-rtsp/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-exoplayer-rtsp/Transforms/Metadata.xml
@@ -12,4 +12,23 @@
       true
     </attr>
 
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.rtsp']/class[@name='RtspMediaSource.Factory']/method[@name='createMediaSource' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.rtsp']/class[@name='RtspMediaSource.Factory']/method[@name='setDrmSessionManagerProvider' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.drm.DrmSessionManagerProvider']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.rtsp']/class[@name='RtspMediaSource.Factory']/method[@name='setLoadErrorHandlingPolicy' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+
 </metadata>

--- a/source/androidx.media3/media3-exoplayer-smoothstreaming/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-exoplayer-smoothstreaming/Transforms/Metadata.xml
@@ -75,5 +75,22 @@
       true
     </attr>
 
-
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.smoothstreaming']/class[@name='SsMediaSource.Factory']/method[@name='createMediaSource' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.smoothstreaming']/class[@name='SsMediaSource.Factory']/method[@name='setDrmSessionManagerProvider' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.drm.DrmSessionManagerProvider']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.smoothstreaming']/class[@name='SsMediaSource.Factory']/method[@name='setLoadErrorHandlingPolicy' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
 </metadata>

--- a/source/androidx.media3/media3-exoplayer/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-exoplayer/Transforms/Metadata.xml
@@ -277,6 +277,18 @@
       true
     </attr>
 
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.drm']/class[@name='DummyExoMediaDrm']/method[@name='getProvisionRequest' and count(parameter)=0]"
+      name="propertyName"
+      >
+    </attr>
+
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.drm']/class[@name='FrameworkMediaDrm']/method[@name='getProvisionRequest' and count(parameter)=0]"
+      name="propertyName"
+      >
+    </attr>
+
 
 
     <attr

--- a/source/androidx.media3/media3-exoplayer/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-exoplayer/Transforms/Metadata.xml
@@ -18,9 +18,6 @@
   <remove-node
     path="/api/package[@name='androidx.media3.exoplayer']/class[@name='SimpleExoPlayer']"
         />
-  <remove-node
-    path="/api/package[@name='androidx.media3.exoplayer.source']/interface[@name='MediaSourceFactory']"
-        />
 
   <!-- Duplicate inherited interface methods -->
   <remove-node

--- a/source/androidx.media3/media3-exoplayer/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-exoplayer/Transforms/Metadata.xml
@@ -290,6 +290,39 @@
     </attr>
 
 
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='DefaultMediaSourceFactory']/method[@name='setLoadErrorHandlingPolicy' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='DefaultMediaSourceFactory']/method[@name='setDrmSessionManagerProvider' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.drm.DrmSessionManagerProvider']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ProgressiveMediaSource.Factory']/method[@name='createMediaSource' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ProgressiveMediaSource.Factory']/method[@name='setDrmSessionManagerProvider' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.drm.DrmSessionManagerProvider']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ProgressiveMediaSource.Factory']/method[@name='setLoadErrorHandlingPolicy' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy']]"
+      name="managedReturn"
+      >
+      AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
+    </attr>
+
 
     <attr
         path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ExternallyLoadedMediaSource']/method[@name='canUpdateMediaItem' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"

--- a/source/androidx.media3/media3-exoplayer/Transforms/Metadata.xml
+++ b/source/androidx.media3/media3-exoplayer/Transforms/Metadata.xml
@@ -173,16 +173,6 @@
   <remove-node
       path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ConcatenatingMediaSource']"
         />
-  <remove-node
-      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ConcatenatingMediaSource2']"
-        />
-  <remove-node
-      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='MergingMediaSource']"
-        />
-  <remove-node
-      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='WrappingMediaSource']"
-        />
-
   <attr 
       path="/api/package[@name='androidx.media3.exoplayer.audio']/interface[@name='AudioSink.Listener']/method[@name='onAudioTrackInitialized' and count(parameter)=1 and parameter[1][@type='androidx.media3.exoplayer.audio.AudioSink.AudioTrackConfig']]"
       name="argsType"
@@ -322,7 +312,20 @@
       >
       AndroidX.Media3.ExoPlayer.Source.IMediaSource.IFactory
     </attr>
+    
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ConcatenatingMediaSource2']/method[@name='onChildSourceInfoRefreshed' and count(parameter)=3 and parameter[1][@type='java.lang.Integer'] and parameter[2][@type='androidx.media3.exoplayer.source.MediaSource'] and parameter[3][@type='androidx.media3.common.Timeline']]/parameter[1]"
+      name="managedType"
+      >
+      Java.Lang.Object
+    </attr>
 
+    <attr 
+      path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='MergingMediaSource']/method[@name='onChildSourceInfoRefreshed' and count(parameter)=3 and parameter[1][@type='java.lang.Integer'] and parameter[2][@type='androidx.media3.exoplayer.source.MediaSource'] and parameter[3][@type='androidx.media3.common.Timeline']]/parameter[1]"
+      name="managedType"
+      >
+      Java.Lang.Object
+    </attr>
 
     <attr
         path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ExternallyLoadedMediaSource']/method[@name='canUpdateMediaItem' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
@@ -331,7 +334,27 @@
         true
     </attr>
     <attr
+        path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ConcatenatingMediaSource2']/method[@name='canUpdateMediaItem' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+        name="final"
+        >
+        true
+    </attr>
+    <attr
         path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ExternallyLoadedMediaSource']/method[@name='updateMediaItem' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+        name="final"
+        >
+      true
+    </attr>
+
+        <attr
+        path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='ConcatenatingMediaSource2']/method[@name='updateMediaItem' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+        name="final"
+        >
+      true
+    </attr>
+
+    <attr
+        path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='MergingMediaSource']/method[@name='canUpdateMediaItem' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
         name="final"
         >
         true
@@ -343,5 +366,17 @@
         AndroidX.Media3.ExoPlayer.Source.IMediaSource
       </attr>
 
+    <attr
+        path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='MergingMediaSource']/method[@name='updateMediaItem' and count(parameter)=1 and parameter[1][@type='androidx.media3.common.MediaItem']]"
+        name="final"
+        >
+      true
+    </attr>
 
+    <attr
+        path="/api/package[@name='androidx.media3.exoplayer.source']/class[@name='WrappingMediaSource']/method[@name='onChildSourceInfoRefreshed' and count(parameter)=3 and parameter[1][@type='java.lang.Void'] and parameter[2][@type='androidx.media3.exoplayer.source.MediaSource'] and parameter[3][@type='androidx.media3.common.Timeline']]"
+        name="final"
+        >
+      false
+    </attr>
 </metadata> 


### PR DESCRIPTION
### Support Libraries Version (eg: 23.3.0):


### Does this change any of the generated binding API's?
Yes, especially due to Media3 now binding with MAUI's binding generator. (See factory changes)

### Describe your contribution
Allows MediaSources to now be set correctly, disables binding for Xamarin.Forms on Media3 so that it's no longer required to remove MediaSourceFactory, bring in ConcatenatingMediaSource2, MergingMediaSource & WrappingMediaSource which were originally removed.

Fixes: #954 