### PR TITLE
[binderator] Don't bump dependencies when running `dotnet cake -t=bump-config`

### DIFF
--- a/build/cake/update-config.cake
+++ b/build/cake/update-config.cake
@@ -1,7 +1,5 @@
 // Contains tasks for updating/modifying the config.json used by binderator
 
-var gps_config = "https://raw.githubusercontent.com/xamarin/GooglePlayServicesComponents/main/config.json";
-
 // Updates config.json to the latest versions found in Maven
 Task ("update-config")
     .Does (() =>
@@ -9,9 +7,7 @@ Task ("update-config")
     var args = new ProcessArgumentBuilder ()
         .Append ("update")
         .Append ("--config-file")
-        .Append ("config.json")
-        .Append ("--dependency-file")
-        .Append (gps_config);
+        .Append ("config.json");
     
     DotNetRun (binderator_project, args);
 });

--- a/config.json
+++ b/config.json
@@ -5669,7 +5669,8 @@
         "version": "1.2.0",
         "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Emoji2",
-        "dependencyOnly": true
+        "dependencyOnly": true,
+        "comments": "Required by 'androidx.emoji2.emoji2-emojipicker:1.5.0'"
       },
       {
         "groupId": "androidx.wear.tiles",
@@ -5677,7 +5678,8 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles",
-        "dependencyOnly": true
+        "dependencyOnly": true,
+        "comments": "Required by 'androidx.wear.tiles.tiles-renderer:1.1.0'"
       },
       {
         "groupId": "androidx.wear.tiles",
@@ -5685,7 +5687,8 @@
         "version": "1.1.0",
         "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Proto",
-        "dependencyOnly": true
+        "dependencyOnly": true,
+        "comments": "Required by 'androidx.wear.tiles.tiles-renderer:1.1.0'"
       },
       {
         "groupId": "com.google.android.gms",
@@ -5693,7 +5696,8 @@
         "version": "20.0.0",
         "nugetVersion": "120.0.0",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Base",
-        "dependencyOnly": true
+        "dependencyOnly": true,
+        "comments": "Required by 'com.google.android.gms.play-services-gass:20.0.0'"
       },
       {
         "groupId": "com.google.android.gms",
@@ -5701,7 +5705,8 @@
         "version": "20.0.0",
         "nugetVersion": "120.0.0",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Lite",
-        "dependencyOnly": true
+        "dependencyOnly": true,
+        "comments": "Required by 'com.google.android.gms.play-services-gass:20.0.0'"
       },
       {
         "groupId": "com.google.android.gms",
@@ -5709,7 +5714,8 @@
         "version": "16.3.0",
         "nugetVersion": "116.3.0",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Base",
-        "dependencyOnly": true
+        "dependencyOnly": true,
+        "comments": "Required by 'com.google.firebase.firebase-analytics-impl:16.3.0'"
       },
       {
         "groupId": "com.xamarin.androidx",
@@ -5717,7 +5723,8 @@
         "version": "1.0",
         "nugetVersion": "1.0.10.1",
         "nugetId": "Xamarin.AndroidX.Migration",
-        "dependencyOnly": true
+        "dependencyOnly": true,
+        "comments": "Required by 'build.cake' script"
       }
     ],
     "licenses": [

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/BumpCommand.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Commands/BumpCommand.cs
@@ -27,7 +27,7 @@ static class BumpCommand
 	{
 		var config = await BindingConfig.Load (configFile);
 
-		foreach (var art in config.MavenArtifacts) {
+		foreach (var art in config.MavenArtifacts.Where (a => !a.DependencyOnly)) {
 			var version = "";
 			var release = "";
 			var revision = 0;


### PR DESCRIPTION
Now that AndroidX and GPS are combined, the remaining `config.json` entries that are `"dependencyOnly": true` are all fixed required versions that should not be updated by the `update` or `bump` commands.

Additionally, use the `comments` field to document why each dependency is listed, as ideally we would like to get to a point where no old fixed versions are required.