### PR TITLE
[tests] Add `--no-restore` to `dotnet` invocations for better performance.

### DIFF
--- a/tests/extended/TestAllIndividualPackages.cs
+++ b/tests/extended/TestAllIndividualPackages.cs
@@ -107,7 +107,7 @@ public class TestAllIndividualPackages
 			ReplaceInFile (activity_file, "public class MainActivity : Activity", "public class MainActivity : global::Android.App.Activity");
 
 		// Add the package
-		await RunAndAssertSuccess ($"add package {id} --version {version}", case_dir);
+		await RunAndAssertSuccess ($"add package {id} --version {version} --no-restore", case_dir);
 
 		// Build the project
 		await RunAndAssertSuccess ($"build -c {configuration} -bl", case_dir, true);


### PR DESCRIPTION
Calling `dotnet add nuget <package>` implicitly does a NuGet restore before returning.

However, after we get the test set up using these commands we call `dotnet build` which _also_ does a NuGet restore.

Improve performance by opting out of this initial restore and only doing the one at build time.