### PR TITLE
Manual updates 20241120 NuGet SBOM generation

### DIFF
--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -148,6 +148,19 @@
     }
   </ItemGroup>
 
+  <PropertyGroup>
+    <GenerateSBOM>true</GenerateSBOM>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+
+
   @{ await IncludeAsync("source/_PackageLevelCustomizations.cshtml", Model); }
 
 </Project>


### PR DESCRIPTION

Add support new nuget package that generates and packs SPDX SBOM into nuget package being built and packaged.

```xml
  <PropertyGroup>
    <GenerateSBOM>true</GenerateSBOM>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.0">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
  </ItemGroup>
```

SBOM can be found

```
./_manifest/spdx_2.2/manifest.spdx.json
```

## Details

https://github.com/microsoft/sbom-tool

https://devblogs.microsoft.com/engineering-at-microsoft/microsoft-open-sources-software-bill-of-materials-sbom-generation-tool/

https://devblogs.microsoft.com/engineering-at-microsoft/generating-software-bills-of-materials-sboms-with-spdx-at-microsoft/

https://www.infoworld.com/article/2336159/build-sboms-with-microsofts-spdx-sbom-generator.html

https://medium.com/@susmeetajagtap/sbom-generation-tools-analysis-1fb6b0c49c0d

https://www.cybeats.com/blog/5-key-takeaways-from-microsoft-and-googles-webinar-on-sbom


