### PR TITLE
[ci] Add dev/* branches to CI trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,7 @@
 trigger:
   - main
   - refs/tags/*
+  - dev/*
 
 pr:
   - main


### PR DESCRIPTION
Adds dev branches to the CI trigger to kick off builds on these branches
automatically now that PR build restrictions are in place for GitHub
repos.