### PR TITLE
[build] Address CVE-2024-43485, CVE-2024-38081

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,6 +76,11 @@
     <DefaultTransformExcludes>**/*.MonoAndroid*.0.xml;**/*.net*.0-android.xml</DefaultTransformExcludes>
   </PropertyGroup>
 
+  <!-- Common PackageReference versions -->
+  <PropertyGroup>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.13.9</MSBuildPackageReferenceVersion>
+  </PropertyGroup>
+
   <!-- Folders that .targets files need to go into -->
   <ItemGroup>
     <AndroidXNuGetTargetFolders Include="build\net8.0-android34.0" />

--- a/source/com.google.android.gms/play-services-basement/buildtasks/Basement-BuildTasks.csproj
+++ b/source/com.google.android.gms/play-services-basement/buildtasks/Basement-BuildTasks.csproj
@@ -10,10 +10,10 @@
     <AssemblyName>Xamarin.GooglePlayServices.Tasks</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.5.0" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.5.0" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.5.0" IncludeAssets="compile" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.5.0" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build" Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" IncludeAssets="compile" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\merge.targets">

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -25,6 +25,7 @@
 
     <ItemGroup>
         <PackageReference Include="RazorLight" Version="2.3.1" />
+        <PackageReference Include="System.Text.Json" Version="6.0.10" />
         <PackageReference Include="MavenNet" Version="2.2.14" />
     </ItemGroup>
 

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
@@ -9,9 +9,9 @@
   <Target Name="Pack"></Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.4.0" PrivateAssets="none" IncludeAssets="all" />
-    <PackageReference Include="Microsoft.Build" Version="17.4.0" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.4.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" PrivateAssets="none" IncludeAssets="all" />
+    <PackageReference Include="Microsoft.Build" Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -39,8 +39,8 @@
     <None Include="..\..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICE.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.4.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.4.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackageReferenceVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/advisories/GHSA-8g4q-xg66-9fp4
Context: https://github.com/advisories/GHSA-hq7w-xv5x-g34j

Consolidates the MSBuild package reference version into a shared prop
and bumps it to the latest to bring in a newer System.Text.Json and
Microsoft.IO.Redist.

Adds a System.Text.Json reference to Xamarin.AndroidBinderator.csproj to
pull in the latest version of that package with the CVE fix.