### PR TITLE
Manual updates 20250224 disabling `Microsoft.Sbom.Targets` nuget and SBOM generation

### DIFF
--- a/source/AndroidXProject.cshtml
+++ b/source/AndroidXProject.cshtml
@@ -149,19 +149,6 @@
     }
   </ItemGroup>
 
-  <PropertyGroup>
-    <GenerateSBOM>true</GenerateSBOM>
-  </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-
-
   @{ await IncludeAsync("source/_PackageLevelCustomizations.cshtml", Model); }
 
 </Project>


### PR DESCRIPTION
disabling `Microsoft.Sbom.Targets` nuget and SBOM generation due to intermittent hangs on MacOSX

Details

https://github.com/microsoft/sbom-tool/issues/946