### PR TITLE
[ci] Remove PR triggers from azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,9 @@
 trigger:
   - main
   - refs/tags/*
-  - dev/*
 
-pr:
-  - main
-  
+pr: none
+
 schedules:
 - cron: '0 0 * * *'
   displayName: Nightly Extended Tests


### PR DESCRIPTION
PR builds are run out of the public azure-pipelines-public.yml pipeline.