### PR TITLE
MavenRepository name fixed to be compatible with cache directory naming

### DIFF
--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory2.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory2.cs
@@ -71,7 +71,7 @@ public static class MavenFactory2
 		if (type == MavenRepoType.Directory)
 			throw new ArgumentException ("Directory repository type not supported");
 		else if (type == MavenRepoType.Url)
-			maven = new MavenRepository (location, location);
+			maven = new MavenRepository (location, new Uri(location).GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Scheme, UriFormat.UriEscaped));
 		else if (type == MavenRepoType.MavenCentral)
 			maven = MavenRepository.Central;
 		else


### PR DESCRIPTION
At the moment when Url repository type is used the cache directory name contains ":" which is invalid symbol in the path. Removing scheme from the repository name allows to create a cache folder.