### PR TITLE
[build] try multi-targeting .NET 8 and 9

### DIFF
--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -19,7 +19,7 @@ variables:
   macosAgentPoolName: VSEng-VSMac-Xamarin-Shared                                      # macOS VM pool name
   
   # Tool variables
-  dotnetVersion: '8.0.408'                                                              # .NET version to install on agent
+  dotnetVersion: '9.0.300'                                                              # .NET version to install on agent
   dotnetWorkloadRollbackFile: 'workloads.json'                                          # Rollback file specifying workload versions to install
   dotnetNuGetOrgSource: 'https://api.nuget.org/v3/index.json'                           # NuGet.org URL to find workloads
   dotnetWorkloadSource: 'https://aka.ms/dotnet6/nuget/index.json'                       # .NET engineering URL to find workloads

--- a/build/scripts/provision-android/provision-android.csproj
+++ b/build/scripts/provision-android/provision-android.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-android</TargetFramework>
+    <TargetFramework>net9.0-android</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,7 @@
   which is tuned for building bindings packages. -->
   <PropertyGroup>
     <!-- Default TFM's we build for -->
-    <_DefaultTargetFrameworks>net8.0-android</_DefaultTargetFrameworks>
+    <_DefaultTargetFrameworks>net8.0-android;net9.0-android</_DefaultTargetFrameworks>
     <_DefaultNetTargetFrameworks>net8.0</_DefaultNetTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/workloads.json
+++ b/workloads.json
@@ -1,10 +1,10 @@
 {
-  "microsoft.net.sdk.android": "34.0.154/8.0.100",
-  "microsoft.net.sdk.ios": "18.0.8319/8.0.100",
-  "microsoft.net.sdk.maccatalyst": "18.0.8319/8.0.100",
-  "microsoft.net.sdk.macos": "15.0.8319/8.0.100",
-  "microsoft.net.sdk.maui": "8.0.100/8.0.100",
-  "microsoft.net.sdk.tvos": "18.0.8319/8.0.100",
-  "microsoft.net.workload.mono.toolchain.current": "8.0.15/8.0.100",
-  "microsoft.net.workload.emscripten.current": "8.0.15/8.0.100"
+  "microsoft.net.sdk.android": "35.0.61/9.0.100",
+  "microsoft.net.sdk.ios": "18.4.9288/9.0.100",
+  "microsoft.net.sdk.maccatalyst": "18.4.9288/9.0.100",
+  "microsoft.net.sdk.macos": "15.4.9288/9.0.100",
+  "microsoft.net.sdk.maui": "9.0.51/9.0.100",
+  "microsoft.net.sdk.tvos": "18.4.9288/9.0.100",
+  "microsoft.net.workload.mono.toolchain.current": "9.0.5/9.0.100",
+  "microsoft.net.workload.emscripten.current": "9.0.5/9.0.100"
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/android-libraries/pull/1118

This is a step to narrow down the API breaks in #1118.

I want to find out if any of them occur between .NET 8 and .NET 9.