### PR TITLE
[build] fix `PublishPipelineArtifact@1` `condition`

### DIFF
--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -71,7 +71,7 @@ jobs:
     - ${{ if ne(parameters.use1ESTemplate, true) }}:
       - task: PublishPipelineArtifact@1
         displayName: Upload logs
+        condition: always()
         inputs:
           artifactName: output-${{ parameters.name }}
           targetPath: ${{ parameters.artifactsPath }}
-          condition: always()


### PR DESCRIPTION
I found that `condition` was indented one too far!

    Upload logs
    Skipping step due to condition evaluation.

And so, I wasn't able to retrieve build logs for failed builds!

I could either get out a ruler & unindent the `condition` by two spaces, or just move it up to be aligned with the block above.

I did a quick review of the other `condition` statements and didn't find any others to fix.