### PR TITLE
Fix `NU1102` error for `Xamarin.AndroidX.Emoji2`

### DIFF
--- a/config.json
+++ b/config.json
@@ -5204,7 +5204,7 @@
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.3",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Emoji2",
         "dependencyOnly": true,
         "comments": "Required by 'androidx.emoji2.emoji2-emojipicker:1.5.0'"


### PR DESCRIPTION
Context: https://github.com/dotnet/android-libraries/pull/1148
Context: https://www.nuget.org/packages/Xamarin.AndroidX.Emoji2/1.2.0.2

When multi-targeting .NET 8 and 9, I got the error:

    generated\androidx.emoji2.emoji2-emojipicker\androidx.emoji2.emoji2-emojipicker.csproj :
    error NU1102: Unable to find package Xamarin.AndroidX.Emoji2 with version (>= 1.2.0.3 && < 1.2.1)

`Xamarin.AndroidX.Emoji2` version 1.2.0.3 doesn't actually exist?!?

I am not 100% sure why this failed when adding .NET 9, as the block in `config.json` seems wrong:

    "nugetVersion": "1.2.0.3",

We should just fix this in `main`, as it will cause some other issue down the line.