### PR TITLE
[ci] set proper `androidSdkRoot` for macOS

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -39,6 +39,7 @@ stages:
         vmImage: macOS-15
       runDotnetNextTest: ${{ parameters.RunDotnetNextTest }}
       use1ESTemplate: false
+      androidSdkRoot: $(Agent.TempDirectory)/android-sdk
 
 - template: build/ci/stage-standard-tests.yml@self
   parameters:

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -9,6 +9,7 @@ parameters:
   runDotnetNextTest: false
   use1ESTemplate: true
   installAndroidDependencies: false
+  androidSdkRoot: C:\Android\android-sdk
 
   tools:                                                            # Additional .NET global tools to install
   - 'Cake.Tool': '5.0.0'
@@ -44,6 +45,7 @@ jobs:
         dotnetTools: ${{ parameters.tools }}
         runDotnetNextTest: ${{ parameters.runDotnetNextTest }}
         installAndroidDependencies: ${{ parameters.installAndroidDependencies }}
+        androidSdkRoot: ${{ parameters.androidSdkRoot }}
 
     - template: build-and-test.yml
       parameters:

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -144,3 +144,4 @@ steps:
         jdkSourceOption: LocalDirectory
         jdkFile: $(JDK_11_FILE_PATH)
         jdkDestinationDirectory: ${{ parameters.javaSdkRoot }}
+        cleanDestinationDirectory: true

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -120,11 +120,11 @@ steps:
         -v:n -bl:output/install-android-dependencies.binlog
       retryCountOnTaskFailure: 3
 
-  - ${{ if eq(parameters.installAndroidDependencies, true) }}:
-    - pwsh: |
-        Write-Host "##vso[task.setvariable variable=ANDROID_SDK_ROOT]${{ parameters.androidSdkRoot }}"
-      displayName: Set ANDROID_SDK_ROOT to ${{ parameters.androidSdkRoot }}
+  - pwsh: |
+      Write-Host "##vso[task.setvariable variable=ANDROID_SDK_ROOT]${{ parameters.androidSdkRoot }}"
+    displayName: Set ANDROID_SDK_ROOT to ${{ parameters.androidSdkRoot }}
 
+  - ${{ if eq(parameters.installAndroidDependencies, true) }}:
     - pwsh: |
         $url = "https://aka.ms/download-jdk/microsoft-jdk-11.0.26-windows-x64.zip"
         if ($IsMacOS) {


### PR DESCRIPTION
I'm still seeing the same error as bc19e528, and I noticed:

    -p:AndroidSdkDirectory=C:\Android\android-sdk

Which is passed in on macOS...

I setup the `androidSdkRoot` parameter to be set to this value on macOS:

    $(Agent.TempDirectory)/android-sdk