### PR TITLE
[ci] Use templates from DevDiv/Xamarin.yaml-templates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,9 +32,8 @@ resources:
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
     - repository: internal-templates
-      type: github
-      name: xamarin/yaml-templates
-      endpoint: xamarin
+      type: git
+      name: DevDiv/Xamarin.yaml-templates
       ref: refs/heads/main
 
 extends:


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/8c741263550cc57bafc30193fa61f39b7df019bc

Updates the repo reference that provides common yaml templates from

  * https://github.com/xamarin/yaml-templates

to

  * https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates