### PR TITLE
[ci] use `$(Agent.TempDirectory)/android-sdk` on all platforms

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -39,7 +39,6 @@ stages:
         vmImage: macOS-15
       runDotnetNextTest: ${{ parameters.RunDotnetNextTest }}
       use1ESTemplate: false
-      androidSdkRoot: $(Agent.TempDirectory)/android-sdk
 
 - template: build/ci/stage-standard-tests.yml@self
   parameters:

--- a/build/ci/build.yml
+++ b/build/ci/build.yml
@@ -9,7 +9,7 @@ parameters:
   runDotnetNextTest: false
   use1ESTemplate: true
   installAndroidDependencies: false
-  androidSdkRoot: C:\Android\android-sdk
+  androidSdkRoot: $(Agent.TempDirectory)/android-sdk
 
   tools:                                                            # Additional .NET global tools to install
   - 'Cake.Tool': '5.0.0'

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -117,7 +117,7 @@ steps:
       arguments: >-
         -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=true -p:AndroidManifestType=GoogleV2
         -p:AndroidSdkDirectory=${{ parameters.androidSdkRoot }}
-        -bl:$(System.DefaultWorkingDirectory)/output/install-android-dependencies.binlog
+        -v:n -bl:output/install-android-dependencies.binlog
       retryCountOnTaskFailure: 3
 
   - pwsh: |

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -117,7 +117,7 @@ steps:
       arguments: >-
         -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=true -p:AndroidManifestType=GoogleV2
         -p:AndroidSdkDirectory=${{ parameters.androidSdkRoot }}
-        -v:n -bl:output/install-android-dependencies.binlog
+        -bl:$(System.DefaultWorkingDirectory)/output/install-android-dependencies.binlog
       retryCountOnTaskFailure: 3
 
   - pwsh: |

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -121,6 +121,7 @@ steps:
       retryCountOnTaskFailure: 3
 
   - pwsh: |
+      Write-Host "##vso[task.setvariable variable=AndroidSdkDirectory]${{ parameters.androidSdkRoot }}"
       Write-Host "##vso[task.setvariable variable=ANDROID_SDK_ROOT]${{ parameters.androidSdkRoot }}"
     displayName: Set ANDROID_SDK_ROOT to ${{ parameters.androidSdkRoot }}
 

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -2,7 +2,7 @@ parameters:
   dotnetTools: []
   runDotnetNextTest: false
   installAndroidDependencies: false
-  androidSdkRoot: C:\Android\android-sdk
+  androidSdkRoot: $(Agent.TempDirectory)/android-sdk
   javaSdkRoot: $(Agent.ToolsDirectory)\jdk11
 
 steps:

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -110,14 +110,25 @@ steps:
       jdkSourceOption: 'PreInstalled'
 
   - task: DotNetCoreCLI@2
-    displayName: Install android dependencies
+    displayName: Install android dependencies GoogleV2
     inputs:
       command: build
       projects: build/scripts/provision-android/provision-android.csproj
       arguments: >-
         -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=true -p:AndroidManifestType=GoogleV2
         -p:AndroidSdkDirectory=${{ parameters.androidSdkRoot }}
-        -v:n -bl:output/install-android-dependencies.binlog
+        -v:n -bl:output/install-android-dependencies-GoogleV2.binlog
+      retryCountOnTaskFailure: 3
+
+  - task: DotNetCoreCLI@2
+    displayName: Install android dependencies Xamarin
+    inputs:
+      command: build
+      projects: build/scripts/provision-android/provision-android.csproj
+      arguments: >-
+        -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=true -p:AndroidManifestType=Xamarin
+        -p:AndroidSdkDirectory=${{ parameters.androidSdkRoot }}
+        -v:n -bl:output/install-android-dependencies-Xamarin.binlog
       retryCountOnTaskFailure: 3
 
   - pwsh: |

--- a/build/scripts/provision-android/provision-android.csproj
+++ b/build/scripts/provision-android/provision-android.csproj
@@ -2,8 +2,10 @@
   <PropertyGroup>
     <TargetFramework>net10.0-android</TargetFramework>
   </PropertyGroup>
-  <!-- Required for .NET 8 projects -->
   <ItemGroup>
+    <!-- Required for .NET 8 projects -->
     <AndroidDependency Include="platforms/android-34" />
+    <!-- Required for -p:AndroidManifestType=GoogleV2 -->
+    <AndroidDependency Include="platform-tools/36.0.0" />
   </ItemGroup>
 </Project>

--- a/build/scripts/provision-android/provision-android.csproj
+++ b/build/scripts/provision-android/provision-android.csproj
@@ -2,10 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net10.0-android</TargetFramework>
   </PropertyGroup>
+  <!-- Required for .NET 8 projects -->
   <ItemGroup>
-    <!-- Required for .NET 8 projects -->
     <AndroidDependency Include="platforms/android-34" />
-    <!-- Required for -p:AndroidManifestType=GoogleV2 -->
-    <AndroidDependency Include="platform-tools/36.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm still setting the wrong Android SDK used on macOS in some cases: `C:\Android\android-sdk`

Let's use `$(Agent.TempDirectory)/android-sdk`, even on Windows.