### PR TITLE
Remove obscure and/or unused packages

### DIFF
--- a/config.json
+++ b/config.json
@@ -1101,13 +1101,6 @@
       },
       {
         "groupId": "androidx.lifecycle",
-        "artifactId": "lifecycle-reactivestreams-ktx",
-        "version": "2.9.0",
-        "nugetVersion": "2.9.0",
-        "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams.Ktx"
-      },
-      {
-        "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime",
         "version": "2.9.0",
         "nugetVersion": "2.9.0",
@@ -1532,13 +1525,6 @@
         "version": "3.3.6",
         "nugetVersion": "3.3.6.2",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2"
-      },
-      {
-        "groupId": "androidx.paging",
-        "artifactId": "paging-rxjava2-ktx",
-        "version": "3.3.6",
-        "nugetVersion": "3.3.6.2",
-        "nugetId": "Xamarin.AndroidX.Paging.RxJava2.Ktx"
       },
       {
         "groupId": "androidx.palette",
@@ -2037,13 +2023,6 @@
       },
       {
         "groupId": "androidx.wear.watchface",
-        "artifactId": "watchface-complications-data-source-ktx",
-        "version": "1.2.1",
-        "nugetVersion": "1.2.1.11",
-        "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data.Source.Ktx"
-      },
-      {
-        "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-rendering",
         "version": "1.2.1",
         "nugetVersion": "1.2.1.11",
@@ -2176,14 +2155,6 @@
         "version": "7.1.1",
         "nugetVersion": "7.1.1.4",
         "nugetId": "Xamarin.Android.Google.BillingClient",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.android.billingclient",
-        "artifactId": "billing-ktx",
-        "version": "7.1.1",
-        "nugetVersion": "7.1.1.4",
-        "nugetId": "Xamarin.Android.Google.BillingClient.Ktx",
         "type": "xbd"
       },
       {
@@ -3261,14 +3232,6 @@
       },
       {
         "groupId": "com.google.android.play",
-        "artifactId": "asset-delivery-ktx",
-        "version": "2.3.0",
-        "nugetVersion": "2.3.0.3",
-        "nugetId": "Xamarin.Google.Android.Play.Asset.Delivery.Ktx",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.android.play",
         "artifactId": "core",
         "version": "1.10.3",
         "nugetVersion": "1.10.3.18",
@@ -3297,14 +3260,6 @@
         "version": "2.1.0",
         "nugetVersion": "2.1.0.14",
         "nugetId": "Xamarin.Google.Android.Play.Feature.Delivery",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.android.play",
-        "artifactId": "feature-delivery-ktx",
-        "version": "2.1.0",
-        "nugetVersion": "2.1.0.14",
-        "nugetId": "Xamarin.Google.Android.Play.Feature.Delivery.Ktx",
         "type": "xbd"
       },
       {
@@ -3463,15 +3418,6 @@
       },
       {
         "groupId": "com.google.firebase",
-        "artifactId": "firebase-ads-lite",
-        "version": "23.6.0",
-        "nugetVersion": "123.6.0.3",
-        "nugetId": "Xamarin.Firebase.Ads.Lite",
-        "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics",
         "version": "22.4.0",
         "nugetVersion": "122.4.0",
@@ -3484,14 +3430,6 @@
         "version": "16.3.0",
         "nugetVersion": "116.3.0.22",
         "nugetId": "Xamarin.Firebase.Analytics.Impl",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-analytics-ktx",
-        "version": "22.4.0",
-        "nugetVersion": "122.4.0",
-        "nugetId": "Xamarin.Firebase.Analytics.Ktx",
         "type": "xbd"
       },
       {
@@ -3512,14 +3450,6 @@
       },
       {
         "groupId": "com.google.firebase",
-        "artifactId": "firebase-appcheck-debug",
-        "version": "18.0.0",
-        "nugetVersion": "118.0.0.6",
-        "nugetId": "Xamarin.Firebase.AppCheck.Debug",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-interop",
         "version": "17.1.0",
         "nugetVersion": "117.1.0.10",
@@ -3528,26 +3458,10 @@
       },
       {
         "groupId": "com.google.firebase",
-        "artifactId": "firebase-appcheck-ktx",
-        "version": "18.0.0",
-        "nugetVersion": "118.0.0.6",
-        "nugetId": "Xamarin.Firebase.AppCheck.Ktx",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-playintegrity",
         "version": "18.0.0",
         "nugetVersion": "118.0.0.6",
         "nugetId": "Xamarin.Firebase.AppCheck.PlayIntegrity",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-appcheck-safetynet",
-        "version": "16.1.2",
-        "nugetVersion": "116.1.2.14",
-        "nugetId": "Xamarin.Firebase.AppCheck.SafetyNet",
         "type": "xbd"
       },
       {
@@ -3572,14 +3486,6 @@
         "version": "20.0.0",
         "nugetVersion": "120.0.0.22",
         "nugetId": "Xamarin.Firebase.Auth.Interop",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-auth-ktx",
-        "version": "23.2.0",
-        "nugetVersion": "123.2.0.2",
-        "nugetId": "Xamarin.Firebase.Auth.Ktx",
         "type": "xbd"
       },
       {
@@ -3624,14 +3530,6 @@
       },
       {
         "groupId": "com.google.firebase",
-        "artifactId": "firebase-config-ktx",
-        "version": "22.1.1",
-        "nugetVersion": "122.1.1",
-        "nugetId": "Xamarin.Firebase.Config.Ktx",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
         "artifactId": "firebase-core",
         "version": "21.1.1",
         "nugetVersion": "121.1.1.15",
@@ -3653,14 +3551,6 @@
         "nugetVersion": "119.4.3",
         "nugetId": "Xamarin.Firebase.Crashlytics",
         "extraDependencies": "com.google.dagger.dagger",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-crashlytics-ktx",
-        "version": "19.4.3",
-        "nugetVersion": "119.4.3",
-        "nugetId": "Xamarin.Firebase.Crashlytics.Ktx",
         "type": "xbd"
       },
       {
@@ -3697,14 +3587,6 @@
       },
       {
         "groupId": "com.google.firebase",
-        "artifactId": "firebase-database-ktx",
-        "version": "21.0.0",
-        "nugetVersion": "121.0.0.6",
-        "nugetId": "Xamarin.Firebase.Database.Ktx",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
         "artifactId": "firebase-datatransport",
         "version": "19.0.0",
         "nugetVersion": "119.0.0.6",
@@ -3717,14 +3599,6 @@
         "version": "22.1.0",
         "nugetVersion": "122.1.0.6",
         "nugetId": "Xamarin.Firebase.Dynamic.Links",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-dynamic-links-ktx",
-        "version": "22.1.0",
-        "nugetVersion": "122.1.0.6",
-        "nugetId": "Xamarin.Firebase.Dynamic.Links.Ktx",
         "type": "xbd"
       },
       {
@@ -3764,28 +3638,10 @@
       },
       {
         "groupId": "com.google.firebase",
-        "artifactId": "firebase-firestore-ktx",
-        "version": "25.1.4",
-        "nugetVersion": "125.1.4",
-        "nugetId": "Xamarin.Firebase.Firestore.Ktx",
-        "type": "xbd",
-        "skipExtendedTests": true,
-        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
-      },
-      {
-        "groupId": "com.google.firebase",
         "artifactId": "firebase-functions",
         "version": "21.2.1",
         "nugetVersion": "121.2.1.2",
         "nugetId": "Xamarin.Firebase.Functions",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-functions-ktx",
-        "version": "21.2.1",
-        "nugetVersion": "121.2.1.2",
-        "nugetId": "Xamarin.Firebase.Functions.Ktx",
         "type": "xbd"
       },
       {
@@ -3826,26 +3682,6 @@
       },
       {
         "groupId": "com.google.firebase",
-        "artifactId": "firebase-inappmessaging-display-ktx",
-        "version": "21.0.2",
-        "nugetVersion": "121.0.2.2",
-        "nugetId": "Xamarin.Firebase.InAppMessaging.Display.Ktx",
-        "type": "xbd",
-        "skipExtendedTests": true,
-        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-inappmessaging-ktx",
-        "version": "21.0.2",
-        "nugetVersion": "121.0.2.2",
-        "nugetId": "Xamarin.Firebase.InAppMessaging.Ktx",
-        "type": "xbd",
-        "skipExtendedTests": true,
-        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
-      },
-      {
-        "groupId": "com.google.firebase",
         "artifactId": "firebase-installations",
         "version": "18.0.0",
         "nugetVersion": "118.0.0.6",
@@ -3858,14 +3694,6 @@
         "version": "17.2.0",
         "nugetVersion": "117.2.0.10",
         "nugetId": "Xamarin.Firebase.Installations.InterOp",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-installations-ktx",
-        "version": "18.0.0",
-        "nugetVersion": "118.0.0.6",
-        "nugetId": "Xamarin.Firebase.Installations.Ktx",
         "type": "xbd"
       },
       {
@@ -3890,22 +3718,6 @@
         "version": "24.1.1",
         "nugetVersion": "124.1.1.2",
         "nugetId": "Xamarin.Firebase.Messaging",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-messaging-directboot",
-        "version": "24.1.1",
-        "nugetVersion": "124.1.1.2",
-        "nugetId": "Xamarin.Firebase.Messaging.DirectBoot",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-messaging-ktx",
-        "version": "24.1.1",
-        "nugetVersion": "124.1.1.2",
-        "nugetId": "Xamarin.Firebase.Messaging.Ktx",
         "type": "xbd"
       },
       {
@@ -4040,16 +3852,6 @@
       },
       {
         "groupId": "com.google.firebase",
-        "artifactId": "firebase-perf-ktx",
-        "version": "21.0.5",
-        "nugetVersion": "121.0.5.2",
-        "nugetId": "Xamarin.Firebase.Perf.Ktx",
-        "type": "xbd",
-        "skipExtendedTests": true,
-        "comments": "Skip tests due to https://github.com/firebase/firebase-android-sdk/issues/5997"
-      },
-      {
-        "groupId": "com.google.firebase",
         "artifactId": "firebase-sessions",
         "version": "2.1.1",
         "nugetVersion": "102.1.1",
@@ -4070,14 +3872,6 @@
         "version": "17.0.0",
         "nugetVersion": "117.0.0.22",
         "nugetId": "Xamarin.Firebase.Storage.Common",
-        "type": "xbd"
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-storage-ktx",
-        "version": "21.0.1",
-        "nugetVersion": "121.0.1.4",
-        "nugetId": "Xamarin.Firebase.Storage.Ktx",
         "type": "xbd"
       },
       {


### PR DESCRIPTION
In an effort to make this repo more maintainable...

This removes packages, in which:
* There are no (or very little) downloads in the last 90 days
* There are no dependent packages listed on NuGet.org

We are mostly focusing on obscure Xamarin.Firebase packages that no one is using.

* https://www.nuget.org/packages/Xamarin.Android.Google.BillingClient.Ktx
* https://www.nuget.org/packages/Xamarin.AndroidX.Lifecycle.ReactiveStreams.Ktx
* https://www.nuget.org/packages/Xamarin.AndroidX.Paging.RxJava2.Ktx
* https://www.nuget.org/packages/Xamarin.AndroidX.Wear.WatchFace.Complications.Data.Source.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Ads.Lite
* https://www.nuget.org/packages/Xamarin.Firebase.Analytics.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.AppCheck.Debug
* https://www.nuget.org/packages/Xamarin.Firebase.AppCheck.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.AppCheck.SafetyNet
* https://www.nuget.org/packages/Xamarin.Firebase.Auth.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Config.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Crashlytics.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Database.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Dynamic.Links.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Firestore.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Functions.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.InAppMessaging.Display.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.InAppMessaging.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Installations.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Messaging.DirectBoot
* https://www.nuget.org/packages/Xamarin.Firebase.Messaging.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Perf.Ktx
* https://www.nuget.org/packages/Xamarin.Firebase.Storage.Ktx
* https://www.nuget.org/packages/Xamarin.Google.Android.Play.Asset.Delivery.Ktx
* https://www.nuget.org/packages/Xamarin.Google.Android.Play.Feature.Delivery.Ktx

Note that any with a `.Ktx` suffix are Kotlin extensions, which are not particularly useful in a C# project.

*Some* `.Ktx` packages are still kept, such as `Xamarin.AndroidX.Activity.Ktx`, which is a dependency of many other AndroidX packages.