### PR TITLE
[build] update to .NET 10 Preview 6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -90,7 +90,7 @@
 
   <!-- Common PackageReference versions -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.13.9</MSBuildPackageReferenceVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.14.8</MSBuildPackageReferenceVersion>
   </PropertyGroup>
 
   <!-- Folders that .targets files need to go into -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -90,7 +90,7 @@
 
   <!-- Common PackageReference versions -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.14.8</MSBuildPackageReferenceVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.13.9</MSBuildPackageReferenceVersion>
   </PropertyGroup>
 
   <!-- Folders that .targets files need to go into -->

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -19,10 +19,9 @@ variables:
   macosAgentPoolName: VSEng-VSMac-Xamarin-Shared                                        # macOS VM pool name
   
   # Tool variables
-  dotnetVersion: '9.0.301'                                                              # .NET version to install on agent
+  dotnetVersion: '9.0.303'                                                              # .NET version to install on agent
   dotnetFrameworkVersion: 9                                                             # The number to use for TF (eg: netX.0-android)
   dotnetNuGetOrgSource: 'https://api.nuget.org/v3/index.json'                           # NuGet.org URL to find workloads
-  dotnetWorkloadSource: 'https://aka.ms/dotnet6/nuget/index.json'                       # .NET engineering URL to find workloads
 
   # Standard test variables
   standardTestProject: tests/allpackages/AllPackagesTests.csproj                                                      # Standard tests project file
@@ -35,9 +34,8 @@ variables:
   extendedTestAssembly: tests/extended/bin/$(configuration)/net$(dotnetFrameworkVersion).0/ExtendedTests.dll    # Extended tests compiled binary
 
   # dotnet-next test variables
-  dotnetNextVersion: 10.0.100-preview.5.25277.114                                       # .NET preview version to install
+  dotnetNextVersion: 10.0.100-preview.6.25358.103                                       # .NET preview version to install
   dotnetNextFrameworkVersion: 10                                                        # The number to use for TF (eg: netX.0-android)
-  dotnetNextApiLevel: 35                                                                # The Android SDK API Level to use (eg: netX.0-androidXX.0)
 
   # dnceng-public variables
   NetCorePublicPoolName: NetCore-Public-XL

--- a/util/Directory.Build.props
+++ b/util/Directory.Build.props
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <_DefaultNetTargetFramework>net9.0</_DefaultNetTargetFramework>
     <!-- Duplicate of root Directory.Build.props -->
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.14.8</MSBuildPackageReferenceVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.13.9</MSBuildPackageReferenceVersion>
   </PropertyGroup>
 </Project>

--- a/util/Directory.Build.props
+++ b/util/Directory.Build.props
@@ -3,5 +3,7 @@
   which is tuned for building bindings packages. -->
   <PropertyGroup>
     <_DefaultNetTargetFramework>net9.0</_DefaultNetTargetFramework>
+    <!-- Duplicate of root Directory.Build.props -->
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.14.8</MSBuildPackageReferenceVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update to:

* .NET SDK 9.0.303
* .NET SDK 10.0.100-preview.6.25358.103

I also removed a couple values that were unused that would cause confusion: `dotnetWorkloadSource` and `dotnetNextApiLevel`.