### PR TITLE
Exclude the OkHttp dependency for the Places API

### DIFF
--- a/config.json
+++ b/config.json
@@ -3176,6 +3176,7 @@
         "version": "4.4.1",
         "nugetVersion": "4.4.1",
         "nugetId": "Xamarin.GoogleAndroid.Libraries.Places",
+        "excludedRuntimeDependencies": "com.squareup.okhttp.okhttp",
         "type": "xbd"
       },
       {


### PR DESCRIPTION
It is not needed as the underlying library uses grpc-okhttp instead. This is a fork and modification of the OkHttp library and the code says it is 2.5.0+

https://github.com/grpc/grpc-java/blob/f50726d32e216746642513add28e086094ce5506/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/Platform.java#L18