### PR TITLE
[build] check if `$(JAVA_HOME_21_X64)` exists instead of agent name

### DIFF
--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -45,7 +45,7 @@ steps:
     displayName: Install .NET Workloads
 
   - bash: |
-      if [[ "$(Agent.Name)" == *"Azure Pipelines"* ]]; then
+      if [[ -d "$(JAVA_HOME_21_X64)" ]]; then
           echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_21_X64)"
       else
           echo "##vso[task.setvariable variable=JAVA_HOME]/Library/Java/JavaVirtualMachines/microsoft-21.jdk/Contents/Home"

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -45,8 +45,8 @@ steps:
     displayName: Install .NET Workloads
 
   - bash: |
-      if [[ -d "$(JAVA_HOME_21_X64)" ]]; then
-          echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_21_X64)"
+      if [[ -n "$JAVA_HOME_21_X64" && -d "$JAVA_HOME_21_X64" ]]; then
+          echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_21_X64"
       else
           echo "##vso[task.setvariable variable=JAVA_HOME]/Library/Java/JavaVirtualMachines/microsoft-21.jdk/Contents/Home"
       fi

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -48,7 +48,16 @@ steps:
       if [[ -n "$JAVA_HOME_21_X64" && -d "$JAVA_HOME_21_X64" ]]; then
           echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_21_X64"
       else
-          echo "##vso[task.setvariable variable=JAVA_HOME]/Library/Java/JavaVirtualMachines/microsoft-21.jdk/Contents/Home"
+          JDK_DIR="$(Agent.ToolsDirectory)/jdk-21"
+          TEMP_FILE="$(Agent.TempDirectory)/microsoft-jdk-21.tar.gz"
+          if [[ ! -d "$JDK_DIR" ]]; then
+              echo "Downloading Microsoft JDK 21 for macOS..."
+              mkdir -p "$JDK_DIR"
+              curl -L "https://aka.ms/download-jdk/microsoft-jdk-21.0.8-macos-x64.tar.gz" -o "$TEMP_FILE"
+              tar -xzf "$TEMP_FILE" -C "$JDK_DIR" --strip-components=1
+              rm "$TEMP_FILE"
+          fi
+          echo "##vso[task.setvariable variable=JAVA_HOME]$JDK_DIR"
       fi
     displayName: Use Java 21 SDK (Mac)
     condition: eq( variables['Agent.OS'], 'Darwin' )

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -50,7 +50,7 @@ steps:
       else
           JDK_DIR="$(Agent.ToolsDirectory)/jdk-21"
           TEMP_FILE="$(Agent.TempDirectory)/microsoft-jdk-21.tar.gz"
-          if [[ ! -d "$JDK_DIR" ]]; then
+          if [[ ! -d "$JDK_DIR" || ! -f "$JDK_DIR/bin/java" ]]; then
               echo "Downloading Microsoft JDK 21 for macOS..."
               mkdir -p "$JDK_DIR"
               curl -L "https://aka.ms/download-jdk/microsoft-jdk-21.0.8-macos-x64.tar.gz" -o "$TEMP_FILE"

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -54,7 +54,7 @@ steps:
               echo "Downloading Microsoft JDK 21 for macOS..."
               mkdir -p "$JDK_DIR"
               curl -L "https://aka.ms/download-jdk/microsoft-jdk-21.0.8-macos-x64.tar.gz" -o "$TEMP_FILE"
-              tar -xzf "$TEMP_FILE" -C "$JDK_DIR" --strip-components=1
+              tar -xzf "$TEMP_FILE" -C "$JDK_DIR" --strip-components=4
               rm "$TEMP_FILE"
           fi
           echo "##vso[task.setvariable variable=JAVA_HOME]$JDK_DIR"


### PR DESCRIPTION
Builds on the `main` branch fail with:

    ERROR: JAVA_HOME is set to an invalid directory: /Library/Java/JavaVirtualMachines/microsoft-21.jdk/Contents/Home

The current code is checking the `$(Agent.Name)`, but it should just check if the directory exists.