### PR TITLE
[tests] ignore tests with `Download failed. Please download...`

### DIFF
--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Helpers/TestsBase.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Helpers/TestsBase.cs
@@ -62,7 +62,8 @@ namespace Xamarin.ContentPipeline.Tests
 					return;
 				}
 			}
-			if (err.Message.Contains ("Could not find 7zip"))
+			if (err.Message.Contains ("Could not find 7zip") || 
+				err.Message.Contains ("Download failed."))
 			{
 				Assert.Skip ("Test ignored due to known issue: " + err.Message);
 			}


### PR DESCRIPTION
This prevents flaky CI on test failures such as:

    Unexpected error: Download failed. Please download https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar to a file called C:\Users\cloudtest\AppData\Local\Temp\tmpaazgjb.tmp\unpacked\FacebookAndroid-4.17.0.aar.
    Stack trace
        at Xamarin.ContentPipeline.Tests.TestsBase.AssertNoMessagesOrWarnings(MSBuildTestLogger logger, String[] ignorePatterns) in C:\a\_work\1\s\util\Xamarin.Build.Download\source\Xamarin.Build.Download.Tests\Helpers\TestsBase.cs:line 71
        at NativeLibraryDownloaderTests.Test.TestUncompressedNamedDownload() in C:\a\_work\1\s\util\Xamarin.Build.Download\source\Xamarin.Build.Download.Tests\Test.cs:line 181
        at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
        at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)