### PR TITLE
[build] increase timeout for signing

### DIFF
--- a/build/ci/stage-sign-artifacts.yml
+++ b/build/ci/stage-sign-artifacts.yml
@@ -10,7 +10,7 @@ stages:
   
   - template: sign-artifacts/jobs/v4.yml@yaml-templates
     parameters:
-      timeoutInMinutes: 120
+      timeoutInMinutes: 180
       artifactName: output-windows
       usePipelineArtifactTasks: true
       checkoutType: self


### PR DESCRIPTION
Signing *appears* to be working, but times out at about 2 hours.

We increased this to 120 minutes in 7087b1e2.

Let's increase the timeout further to 180 minutes to see if that helps.