### PR TITLE
Disable macOS build lane due to frequent timeouts

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -21,9 +21,11 @@ stages:
       use1ESTemplate: false
       installAndroidDependencies: true
 
+# Disabled: macOS lane frequently times out and its output is unused.
 - stage: build_mac
   displayName: Build - Mac
   dependsOn: []
+  condition: false
   jobs:
   - template: build/ci/build.yml@self
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,9 +61,11 @@ extends:
             os: windows
           runAPIScan: true
 
+    # Disabled: macOS lane frequently times out and its output is unused.
     - stage: build_mac
       displayName: Build - Mac
       dependsOn: []
+      condition: false
       
       jobs:
       - template: build/ci/build.yml@self


### PR DESCRIPTION
The macOS `build_mac` stage has been timing out repeatedly on both the public PR pipeline (e.g. [build #1430243](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1430243)) and the internal `main` pipeline (e.g. [build #14092381](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14092381)), creating noisy red builds.

The lane builds the same `build/ci/build.yml` template as the Windows lane, and nothing downstream consumes its output — `stage-standard-tests`, `stage-extended-tests`, and `stage-sign-artifacts` all run from the Windows build. It is effectively a parallel smoke test.

This change adds `condition: false` (plus a brief comment) to the `build_mac` stage in both `azure-pipelines.yml` and `azure-pipelines-public.yml` so the stage is skipped until the timeouts are understood. We can re-enable it later, optionally restricted to the nightly cron, once we have a fix.