### PR TITLE
Add RollForward=Major to test/util projects

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,5 +4,8 @@
   <PropertyGroup>
     <!-- Default TFM's we build for -->
     <_DefaultNetTargetFramework>net9.0</_DefaultNetTargetFramework>
+    <!-- Allow tests to run on newer runtimes (e.g. .NET 10) when the targeted
+         runtime isn't installed on the build agent. -->
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 </Project>

--- a/util/Directory.Build.props
+++ b/util/Directory.Build.props
@@ -3,6 +3,9 @@
   which is tuned for building bindings packages. -->
   <PropertyGroup>
     <_DefaultNetTargetFramework>net9.0</_DefaultNetTargetFramework>
+    <!-- Allow tests/tools to run on newer runtimes (e.g. .NET 10) when the
+         targeted runtime isn't installed on the build agent. -->
+    <RollForward>Major</RollForward>
     <!-- Duplicate of root Directory.Build.props -->
     <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.13.9</MSBuildPackageReferenceVersion>
   </PropertyGroup>


### PR DESCRIPTION
The hosted build agents were updated and no longer have the .NET 9 x64 runtime installed (only x86), so `net9.0` test apps fail to launch:

```
Testhost process for source(s) '...\AllPackagesTests.dll' exited with error:
  You must install or update .NET to run this application.
App: ...\testhost.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '9.0.0' (x64)
The following frameworks were found:
  10.0.8 at [C:\hostedtoolcache\windows\dotnet\shared\Microsoft.NETCore.App]
```

Seen in [DevDiv AndroidX build 14212627](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14212627) (release/net9.0).

Setting `<RollForward>Major</RollForward>` in `tests/Directory.Build.props` and `util/Directory.Build.props` lets the `net9.0` testhost roll forward to the installed .NET 10 runtime on the agent.