### PR TITLE
Rebuild Compose.Material3.Android to pick up CornerBasedShape APIs (#1452)

### DIFF
--- a/config.json
+++ b/config.json
@@ -393,7 +393,7 @@
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-android",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.3",
+        "nugetVersion": "1.4.0.4",
         "nugetId": "Xamarin.AndroidX.Compose.Material3Android"
       },
       {

--- a/source/androidx.compose.material3/material3-android/PublicAPI/PublicAPI.Unshipped.txt
+++ b/source/androidx.compose.material3/material3-android/PublicAPI/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 AndroidX.Compose.Material3.AlertDialogDefaults
 AndroidX.Compose.Material3.AlertDialogDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.AlertDialogDefaults.GetIconContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.AlertDialogDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.AlertDialogDefaults.GetTextContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.AlertDialogDefaults.GetTitleContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.AlertDialogDefaults.TonalElevation.get -> float
@@ -18,6 +19,7 @@ AndroidX.Compose.Material3.AppBarMenuState.IsExpanded.get -> bool
 AndroidX.Compose.Material3.AppBarMenuState.Show() -> void
 AndroidX.Compose.Material3.AppBarRowKt
 AndroidX.Compose.Material3.AssistChipDefaults
+AndroidX.Compose.Material3.AssistChipDefaults.AssistChipBorder(bool enabled, long borderColor, long disabledBorderColor, float borderWidth, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.AssistChipDefaults.AssistChipBorder(long borderColor, long disabledBorderColor, float borderWidth, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.ChipBorder!
 AndroidX.Compose.Material3.AssistChipDefaults.AssistChipColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ChipColors!
 AndroidX.Compose.Material3.AssistChipDefaults.AssistChipColors(long containerColor, long labelColor, long leadingIconContentColor, long trailingIconContentColor, long disabledContainerColor, long disabledLabelColor, long disabledLeadingIconContentColor, long disabledTrailingIconContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> AndroidX.Compose.Material3.ChipColors!
@@ -25,6 +27,7 @@ AndroidX.Compose.Material3.AssistChipDefaults.AssistChipElevation(float elevatio
 AndroidX.Compose.Material3.AssistChipDefaults.ElevatedAssistChipColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ChipColors!
 AndroidX.Compose.Material3.AssistChipDefaults.ElevatedAssistChipColors(long containerColor, long labelColor, long leadingIconContentColor, long trailingIconContentColor, long disabledContainerColor, long disabledLabelColor, long disabledLeadingIconContentColor, long disabledTrailingIconContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> AndroidX.Compose.Material3.ChipColors!
 AndroidX.Compose.Material3.AssistChipDefaults.ElevatedAssistChipElevation(float elevation, float pressedElevation, float focusedElevation, float hoveredElevation, float draggedElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.ChipElevation!
+AndroidX.Compose.Material3.AssistChipDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.AssistChipDefaults.Height.get -> float
 AndroidX.Compose.Material3.AssistChipDefaults.IconSize.get -> float
 AndroidX.Compose.Material3.BadgeDefaults
@@ -32,15 +35,22 @@ AndroidX.Compose.Material3.BadgeDefaults.GetContainerColor(AndroidX.Compose.Runt
 AndroidX.Compose.Material3.BadgeKt
 AndroidX.Compose.Material3.BottomAppBarDefaults
 AndroidX.Compose.Material3.BottomAppBarDefaults.ContainerElevation.get -> float
+AndroidX.Compose.Material3.BottomAppBarDefaults.ContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.BottomAppBarDefaults.ExitAlwaysScrollBehavior(AndroidX.Compose.Material3.IBottomAppBarState? state, Kotlin.Jvm.Functions.IFunction0? canScroll, AndroidX.Compose.Animation.Core.IAnimationSpec? snapAnimationSpec, AndroidX.Compose.Animation.Core.IDecayAnimationSpec? flingAnimationSpec, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.IBottomAppBarScrollBehavior!
 AndroidX.Compose.Material3.BottomAppBarDefaults.GetBottomAppBarFabColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.BottomAppBarDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.BottomAppBarDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.BottomAppBarState
 AndroidX.Compose.Material3.BottomAppBarStateCompanion
 AndroidX.Compose.Material3.BottomAppBarStateConsts
 AndroidX.Compose.Material3.BottomSheetDefaults
+AndroidX.Compose.Material3.BottomSheetDefaults.DragHandle(AndroidX.Compose.UI.IModifier? modifier, float width, float height, AndroidX.Compose.UI.Graphics.IShape? shape, long color, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> void
 AndroidX.Compose.Material3.BottomSheetDefaults.Elevation.get -> float
 AndroidX.Compose.Material3.BottomSheetDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.BottomSheetDefaults.GetExpandedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.BottomSheetDefaults.GetHiddenShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.BottomSheetDefaults.GetScrimColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.BottomSheetDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.BottomSheetDefaults.SheetMaxWidth.get -> float
 AndroidX.Compose.Material3.BottomSheetDefaults.SheetPeekHeight.get -> float
 AndroidX.Compose.Material3.BottomSheetScaffoldKt
@@ -59,20 +69,31 @@ AndroidX.Compose.Material3.ButtonDefaults
 AndroidX.Compose.Material3.ButtonDefaults.ButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.ButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.ButtonElevation(float defaultElevation, float pressedElevation, float focusedElevation, float hoveredElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> AndroidX.Compose.Material3.ButtonElevation!
+AndroidX.Compose.Material3.ButtonDefaults.ButtonWithIconContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.ButtonDefaults.ContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
 AndroidX.Compose.Material3.ButtonDefaults.ElevatedButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.ElevatedButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.ElevatedButtonElevation(float defaultElevation, float pressedElevation, float focusedElevation, float hoveredElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> AndroidX.Compose.Material3.ButtonElevation!
 AndroidX.Compose.Material3.ButtonDefaults.FilledTonalButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.FilledTonalButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.FilledTonalButtonElevation(float defaultElevation, float pressedElevation, float focusedElevation, float hoveredElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> AndroidX.Compose.Material3.ButtonElevation!
+AndroidX.Compose.Material3.ButtonDefaults.GetElevatedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.ButtonDefaults.GetFilledTonalShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.ButtonDefaults.GetOutlinedButtonBorder(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
+AndroidX.Compose.Material3.ButtonDefaults.GetOutlinedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.ButtonDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.ButtonDefaults.GetTextShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.ButtonDefaults.IconSize.get -> float
 AndroidX.Compose.Material3.ButtonDefaults.IconSpacing.get -> float
 AndroidX.Compose.Material3.ButtonDefaults.MinHeight.get -> float
 AndroidX.Compose.Material3.ButtonDefaults.MinWidth.get -> float
+AndroidX.Compose.Material3.ButtonDefaults.OutlinedButtonBorder(bool enabled, AndroidX.Compose.Runtime.IComposer? _composer, int p2, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.ButtonDefaults.OutlinedButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.OutlinedButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.TextButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
 AndroidX.Compose.Material3.ButtonDefaults.TextButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.ButtonColors!
+AndroidX.Compose.Material3.ButtonDefaults.TextButtonContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.ButtonDefaults.TextButtonWithIconContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
 AndroidX.Compose.Material3.ButtonElevation
 AndroidX.Compose.Material3.ButtonKt
 AndroidX.Compose.Material3.CalendarLocale_androidKt
@@ -90,6 +111,10 @@ AndroidX.Compose.Material3.CardDefaults.CardElevation(float defaultElevation, fl
 AndroidX.Compose.Material3.CardDefaults.ElevatedCardColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.CardColors!
 AndroidX.Compose.Material3.CardDefaults.ElevatedCardColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.CardColors!
 AndroidX.Compose.Material3.CardDefaults.ElevatedCardElevation(float defaultElevation, float pressedElevation, float focusedElevation, float hoveredElevation, float draggedElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.CardElevation!
+AndroidX.Compose.Material3.CardDefaults.GetElevatedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.CardDefaults.GetOutlinedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.CardDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.CardDefaults.OutlinedCardBorder(bool enabled, AndroidX.Compose.Runtime.IComposer? _composer, int p2, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.CardDefaults.OutlinedCardColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.CardColors!
 AndroidX.Compose.Material3.CardDefaults.OutlinedCardColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.CardColors!
 AndroidX.Compose.Material3.CardDefaults.OutlinedCardElevation(float defaultElevation, float pressedElevation, float focusedElevation, float hoveredElevation, float draggedElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.CardElevation!
@@ -98,7 +123,19 @@ AndroidX.Compose.Material3.CardKt
 AndroidX.Compose.Material3.Carousel.CarouselDefaults
 AndroidX.Compose.Material3.Carousel.CarouselDefaults.MaxSmallItemSize.get -> float
 AndroidX.Compose.Material3.Carousel.CarouselDefaults.MinSmallItemSize.get -> float
+AndroidX.Compose.Material3.Carousel.CarouselDefaults.MultiBrowseFlingBehavior(AndroidX.Compose.Material3.Carousel.CarouselState! state, AndroidX.Compose.Animation.Core.IDecayAnimationSpec? decayAnimationSpec, AndroidX.Compose.Animation.Core.IAnimationSpec? snapAnimationSpec, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Foundation.Gestures.ITargetedFlingBehavior!
+AndroidX.Compose.Material3.Carousel.CarouselDefaults.NoSnapFlingBehavior(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Gestures.ITargetedFlingBehavior!
+AndroidX.Compose.Material3.Carousel.CarouselDefaults.SingleAdvanceFlingBehavior(AndroidX.Compose.Material3.Carousel.CarouselState! state, AndroidX.Compose.Animation.Core.IAnimationSpec? snapAnimationSpec, AndroidX.Compose.Runtime.IComposer? _composer, int p3, int _changed) -> AndroidX.Compose.Foundation.Gestures.ITargetedFlingBehavior!
 AndroidX.Compose.Material3.Carousel.CarouselKt
+AndroidX.Compose.Material3.Carousel.CarouselState
+AndroidX.Compose.Material3.Carousel.CarouselState.AnimateScrollToItem(int item, AndroidX.Compose.Animation.Core.IAnimationSpec! animationSpec, Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
+AndroidX.Compose.Material3.Carousel.CarouselState.CarouselState(int currentItem, float currentItemOffsetFraction, Kotlin.Jvm.Functions.IFunction0! itemCount) -> void
+AndroidX.Compose.Material3.Carousel.CarouselState.Companion
+AndroidX.Compose.Material3.Carousel.CarouselState.CurrentItem.get -> int
+AndroidX.Compose.Material3.Carousel.CarouselState.DispatchRawDelta(float delta) -> float
+AndroidX.Compose.Material3.Carousel.CarouselState.IsScrollInProgress.get -> bool
+AndroidX.Compose.Material3.Carousel.CarouselState.Scroll(AndroidX.Compose.Foundation.MutatePriority! scrollPriority, Kotlin.Jvm.Functions.IFunction2! block, Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
+AndroidX.Compose.Material3.Carousel.CarouselState.ScrollToItem(int item, Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
 AndroidX.Compose.Material3.Carousel.CarouselStateKt
 AndroidX.Compose.Material3.Carousel.ICarouselItemDrawInfo
 AndroidX.Compose.Material3.Carousel.ICarouselItemDrawInfo.MaxSize.get -> float
@@ -106,6 +143,9 @@ AndroidX.Compose.Material3.Carousel.ICarouselItemDrawInfo.MinSize.get -> float
 AndroidX.Compose.Material3.Carousel.ICarouselItemDrawInfo.Size.get -> float
 AndroidX.Compose.Material3.Carousel.ICarouselItemScope
 AndroidX.Compose.Material3.Carousel.ICarouselItemScope.CarouselItemDrawInfo.get -> AndroidX.Compose.Material3.Carousel.ICarouselItemDrawInfo!
+AndroidX.Compose.Material3.Carousel.ICarouselItemScope.MaskBorder(AndroidX.Compose.UI.IModifier! p0, AndroidX.Compose.Foundation.BorderStroke! p1, AndroidX.Compose.UI.Graphics.IShape! p2, AndroidX.Compose.Runtime.IComposer? p3, int p4) -> AndroidX.Compose.UI.IModifier!
+AndroidX.Compose.Material3.Carousel.ICarouselItemScope.MaskClip(AndroidX.Compose.UI.IModifier! p0, AndroidX.Compose.UI.Graphics.IShape! p1, AndroidX.Compose.Runtime.IComposer? p2, int p3) -> AndroidX.Compose.UI.IModifier!
+AndroidX.Compose.Material3.Carousel.ICarouselItemScope.RememberMaskShape(AndroidX.Compose.UI.Graphics.IShape! p0, AndroidX.Compose.Runtime.IComposer? p1, int p2) -> AndroidX.Compose.Foundation.Shape.GenericShape!
 AndroidX.Compose.Material3.Carousel.KeylineListKt
 AndroidX.Compose.Material3.Carousel.KeylineSnapPositionKt
 AndroidX.Compose.Material3.Carousel.KeylinesKt
@@ -236,7 +276,10 @@ AndroidX.Compose.Material3.DatePickerDefaults.AllDates.get -> AndroidX.Compose.M
 AndroidX.Compose.Material3.DatePickerDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.DatePickerColors!
 AndroidX.Compose.Material3.DatePickerDefaults.Colors(long containerColor, long titleContentColor, long headlineContentColor, long weekdayContentColor, long subheadContentColor, long navigationContentColor, long yearContentColor, long disabledYearContentColor, long currentYearContentColor, long selectedYearContentColor, long disabledSelectedYearContentColor, long selectedYearContainerColor, long disabledSelectedYearContainerColor, long dayContentColor, long disabledDayContentColor, long selectedDayContentColor, long disabledSelectedDayContentColor, long selectedDayContainerColor, long disabledSelectedDayContainerColor, long todayContentColor, long todayDateBorderColor, long dayInSelectionRangeContentColor, long dayInSelectionRangeContainerColor, long dividerColor, AndroidX.Compose.Material3.TextFieldColors? dateTextFieldColors, AndroidX.Compose.Runtime.IComposer? _composer, int p26, int _changed, int _changed1, int _changed2) -> AndroidX.Compose.Material3.DatePickerColors!
 AndroidX.Compose.Material3.DatePickerDefaults.DateFormatter(string! yearSelectionSkeleton, string! selectedDateSkeleton, string! selectedDateDescriptionSkeleton) -> AndroidX.Compose.Material3.IDatePickerFormatter!
+AndroidX.Compose.Material3.DatePickerDefaults.DatePickerHeadline(Java.Lang.Long? selectedDateMillis, int p1, AndroidX.Compose.Material3.IDatePickerFormatter! dateFormatter, AndroidX.Compose.UI.IModifier? modifier, long contentColor, AndroidX.Compose.Runtime.IComposer? _composer, int displayMode, int _changed) -> void
+AndroidX.Compose.Material3.DatePickerDefaults.DatePickerTitle(int p0, AndroidX.Compose.UI.IModifier? modifier, long contentColor, AndroidX.Compose.Runtime.IComposer? _composer, int displayMode, int _changed) -> void
 AndroidX.Compose.Material3.DatePickerDefaults.GetDefaultDatePickerColors(AndroidX.Compose.Material3.ColorScheme! _this_defaultDatePickerColors, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.DatePickerColors!
+AndroidX.Compose.Material3.DatePickerDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.DatePickerDefaults.TonalElevation.get -> float
 AndroidX.Compose.Material3.DatePickerDefaults.YearRange.get -> Kotlin.Ranges.IntRange!
 AndroidX.Compose.Material3.DatePickerDialog_androidKt
@@ -244,7 +287,12 @@ AndroidX.Compose.Material3.DatePickerKt
 AndroidX.Compose.Material3.DatePicker_jvmKt
 AndroidX.Compose.Material3.DateRangeInputKt
 AndroidX.Compose.Material3.DateRangePickerDefaults
+AndroidX.Compose.Material3.DateRangePickerDefaults.DateRangePickerHeadline(Java.Lang.Long? selectedStartDateMillis, Java.Lang.Long? selectedEndDateMillis, int p2, AndroidX.Compose.Material3.IDatePickerFormatter! dateFormatter, AndroidX.Compose.UI.IModifier? modifier, long contentColor, AndroidX.Compose.Runtime.IComposer? _composer, int displayMode, int _changed) -> void
+AndroidX.Compose.Material3.DateRangePickerDefaults.DateRangePickerTitle(int p0, AndroidX.Compose.UI.IModifier? modifier, long contentColor, AndroidX.Compose.Runtime.IComposer? _composer, int displayMode, int _changed) -> void
 AndroidX.Compose.Material3.DateRangePickerKt
+AndroidX.Compose.Material3.DefaultTooltipCaretShape
+AndroidX.Compose.Material3.DefaultTooltipCaretShape.CaretSize.get -> long
+AndroidX.Compose.Material3.DefaultTooltipCaretShape.CreateOutline(long size, AndroidX.Compose.UI.Unit.LayoutDirection! layoutDirection, AndroidX.Compose.UI.Unit.IDensity! density) -> AndroidX.Compose.UI.Graphics.Outline!
 AndroidX.Compose.Material3.DisplayMode
 AndroidX.Compose.Material3.DisplayMode.Companion
 AndroidX.Compose.Material3.DisplayMode.Companion.Input_jFl_4v0.get -> int
@@ -259,6 +307,10 @@ AndroidX.Compose.Material3.DragHandleColors.DraggedColor.get -> long
 AndroidX.Compose.Material3.DragHandleColors.PressedColor.get -> long
 AndroidX.Compose.Material3.DragHandleKt
 AndroidX.Compose.Material3.DragHandleShapes
+AndroidX.Compose.Material3.DragHandleShapes.DragHandleShapes(AndroidX.Compose.UI.Graphics.IShape! shape, AndroidX.Compose.UI.Graphics.IShape! pressedShape, AndroidX.Compose.UI.Graphics.IShape! draggedShape) -> void
+AndroidX.Compose.Material3.DragHandleShapes.DraggedShape.get -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.DragHandleShapes.PressedShape.get -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.DragHandleShapes.Shape.get -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.DragHandleSizes
 AndroidX.Compose.Material3.DragHandleSizes.DraggedSize.get -> long
 AndroidX.Compose.Material3.DragHandleSizes.PressedSize.get -> long
@@ -268,11 +320,14 @@ AndroidX.Compose.Material3.DrawerDefaults.DismissibleDrawerElevation.get -> floa
 AndroidX.Compose.Material3.DrawerDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.DrawerDefaults.GetModalContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.DrawerDefaults.GetScrimColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.DrawerDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.DrawerDefaults.GetStandardContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.DrawerDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.DrawerDefaults.MaximumDrawerWidth.get -> float
 AndroidX.Compose.Material3.DrawerDefaults.ModalDrawerElevation.get -> float
 AndroidX.Compose.Material3.DrawerDefaults.PermanentDrawerElevation.get -> float
 AndroidX.Compose.Material3.DrawerState
+AndroidX.Compose.Material3.DrawerState.AnimateTo(AndroidX.Compose.Material3.DrawerValue! targetValue, AndroidX.Compose.Animation.Core.IAnimationSpec! anim, Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
 AndroidX.Compose.Material3.DrawerState.Close(Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
 AndroidX.Compose.Material3.DrawerState.Companion
 AndroidX.Compose.Material3.DrawerState.CurrentOffset.get -> float
@@ -295,8 +350,15 @@ AndroidX.Compose.Material3.ExposedDropdownMenuAnchorType.Companion.PrimaryEditab
 AndroidX.Compose.Material3.ExposedDropdownMenuAnchorType.Companion.PrimaryNotEditable_oYjWRB4.get -> string!
 AndroidX.Compose.Material3.ExposedDropdownMenuAnchorType.Companion.SecondaryEditable_oYjWRB4.get -> string!
 AndroidX.Compose.Material3.ExposedDropdownMenuBoxScope
+AndroidX.Compose.Material3.ExposedDropdownMenuBoxScope.ExposedDropdownMenu(bool expanded, Kotlin.Jvm.Functions.IFunction0! onDismissRequest, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Foundation.ScrollState? scrollState, bool focusable, bool matchTextFieldWidth, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.BorderStroke? border, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
+AndroidX.Compose.Material3.ExposedDropdownMenuBoxScope.ExposedDropdownMenu(bool expanded, Kotlin.Jvm.Functions.IFunction0! onDismissRequest, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Foundation.ScrollState? scrollState, bool matchAnchorWidth, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.BorderStroke? border, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p12, int _changed, int _changed1) -> void
 AndroidX.Compose.Material3.ExposedDropdownMenuBoxScope.ExposedDropdownMenuBoxScope(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+AndroidX.Compose.Material3.ExposedDropdownMenuBoxScope.MenuAnchor(AndroidX.Compose.UI.IModifier! _this_menuAnchor) -> AndroidX.Compose.UI.IModifier!
 AndroidX.Compose.Material3.ExposedDropdownMenuDefaults
+AndroidX.Compose.Material3.ExposedDropdownMenuDefaults.ItemContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.ExposedDropdownMenuDefaults.OutlinedTextFieldColors(long focusedTextColor, long unfocusedTextColor, long disabledTextColor, long errorTextColor, long focusedContainerColor, long unfocusedContainerColor, long disabledContainerColor, long errorContainerColor, long cursorColor, long errorCursorColor, AndroidX.Compose.Foundation.Text.Selection.TextSelectionColors? selectionColors, long focusedBorderColor, long unfocusedBorderColor, long disabledBorderColor, long errorBorderColor, long focusedLeadingIconColor, long unfocusedLeadingIconColor, long disabledLeadingIconColor, long errorLeadingIconColor, long focusedTrailingIconColor, long unfocusedTrailingIconColor, long disabledTrailingIconColor, long errorTrailingIconColor, long focusedLabelColor, long unfocusedLabelColor, long disabledLabelColor, long errorLabelColor, long focusedPlaceholderColor, long unfocusedPlaceholderColor, long disabledPlaceholderColor, long errorPlaceholderColor, long focusedPrefixColor, long unfocusedPrefixColor, long disabledPrefixColor, long errorPrefixColor, long focusedSuffixColor, long unfocusedSuffixColor, long disabledSuffixColor, long errorSuffixColor, AndroidX.Compose.Runtime.IComposer? _composer, int p40, int p41, int _changed, int _changed1, int _changed2, int _changed3) -> AndroidX.Compose.Material3.TextFieldColors!
+AndroidX.Compose.Material3.ExposedDropdownMenuDefaults.TextFieldColors(long focusedTextColor, long unfocusedTextColor, long disabledTextColor, long errorTextColor, long focusedContainerColor, long unfocusedContainerColor, long disabledContainerColor, long errorContainerColor, long cursorColor, long errorCursorColor, AndroidX.Compose.Foundation.Text.Selection.TextSelectionColors? selectionColors, long focusedIndicatorColor, long unfocusedIndicatorColor, long disabledIndicatorColor, long errorIndicatorColor, long focusedLeadingIconColor, long unfocusedLeadingIconColor, long disabledLeadingIconColor, long errorLeadingIconColor, long focusedTrailingIconColor, long unfocusedTrailingIconColor, long disabledTrailingIconColor, long errorTrailingIconColor, long focusedLabelColor, long unfocusedLabelColor, long disabledLabelColor, long errorLabelColor, long focusedPlaceholderColor, long unfocusedPlaceholderColor, long disabledPlaceholderColor, long errorPlaceholderColor, long focusedPrefixColor, long unfocusedPrefixColor, long disabledPrefixColor, long errorPrefixColor, long focusedSuffixColor, long unfocusedSuffixColor, long disabledSuffixColor, long errorSuffixColor, AndroidX.Compose.Runtime.IComposer? _composer, int p40, int p41, int _changed, int _changed1, int _changed2, int _changed3) -> AndroidX.Compose.Material3.TextFieldColors!
+AndroidX.Compose.Material3.ExposedDropdownMenuDefaults.TrailingIcon(bool expanded, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Runtime.IComposer? _composer, int p3, int _changed) -> void
 AndroidX.Compose.Material3.ExposedDropdownMenuKt
 AndroidX.Compose.Material3.ExposedDropdownMenu_androidKt
 AndroidX.Compose.Material3.FabPosition
@@ -309,15 +371,21 @@ AndroidX.Compose.Material3.FilterChipDefaults
 AndroidX.Compose.Material3.FilterChipDefaults.ElevatedFilterChipColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.SelectableChipColors!
 AndroidX.Compose.Material3.FilterChipDefaults.ElevatedFilterChipColors(long containerColor, long labelColor, long iconColor, long disabledContainerColor, long disabledLabelColor, long disabledLeadingIconColor, long disabledTrailingIconColor, long selectedContainerColor, long disabledSelectedContainerColor, long selectedLabelColor, long selectedLeadingIconColor, long selectedTrailingIconColor, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> AndroidX.Compose.Material3.SelectableChipColors!
 AndroidX.Compose.Material3.FilterChipDefaults.ElevatedFilterChipElevation(float elevation, float pressedElevation, float focusedElevation, float hoveredElevation, float draggedElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.SelectableChipElevation!
+AndroidX.Compose.Material3.FilterChipDefaults.FilterChipBorder(bool enabled, bool selected, long borderColor, long selectedBorderColor, long disabledBorderColor, long disabledSelectedBorderColor, float borderWidth, float selectedBorderWidth, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.FilterChipDefaults.FilterChipColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.SelectableChipColors!
 AndroidX.Compose.Material3.FilterChipDefaults.FilterChipColors(long containerColor, long labelColor, long iconColor, long disabledContainerColor, long disabledLabelColor, long disabledLeadingIconColor, long disabledTrailingIconColor, long selectedContainerColor, long disabledSelectedContainerColor, long selectedLabelColor, long selectedLeadingIconColor, long selectedTrailingIconColor, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> AndroidX.Compose.Material3.SelectableChipColors!
 AndroidX.Compose.Material3.FilterChipDefaults.FilterChipElevation(float elevation, float pressedElevation, float focusedElevation, float hoveredElevation, float draggedElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.SelectableChipElevation!
+AndroidX.Compose.Material3.FilterChipDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.FilterChipDefaults.Height.get -> float
 AndroidX.Compose.Material3.FilterChipDefaults.IconSize.get -> float
 AndroidX.Compose.Material3.FloatingActionButtonDefaults
 AndroidX.Compose.Material3.FloatingActionButtonDefaults.BottomAppBarFabElevation(float defaultElevation, float pressedElevation, float focusedElevation, float hoveredElevation) -> AndroidX.Compose.Material3.FloatingActionButtonElevation!
 AndroidX.Compose.Material3.FloatingActionButtonDefaults.Elevation(float defaultElevation, float pressedElevation, float focusedElevation, float hoveredElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.FloatingActionButtonElevation!
 AndroidX.Compose.Material3.FloatingActionButtonDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.FloatingActionButtonDefaults.GetExtendedFabShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.FloatingActionButtonDefaults.GetLargeShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.FloatingActionButtonDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.FloatingActionButtonDefaults.GetSmallShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.FloatingActionButtonDefaults.LargeIconSize.get -> float
 AndroidX.Compose.Material3.FloatingActionButtonDefaults.LoweredElevation(float defaultElevation, float pressedElevation, float focusedElevation, float hoveredElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.FloatingActionButtonElevation!
 AndroidX.Compose.Material3.FloatingActionButtonElevation
@@ -331,7 +399,10 @@ AndroidX.Compose.Material3.IAppBarScope.ClickableItem(Kotlin.Jvm.Functions.IFunc
 AndroidX.Compose.Material3.IAppBarScope.CustomItem(Kotlin.Jvm.Functions.IFunction2! p0, Kotlin.Jvm.Functions.IFunction3! p1) -> void
 AndroidX.Compose.Material3.IAppBarScope.ToggleableItem(bool checked, Kotlin.Jvm.Functions.IFunction1! onCheckedChange, Kotlin.Jvm.Functions.IFunction2! p2, string! label, bool enabled) -> void
 AndroidX.Compose.Material3.IBottomAppBarScrollBehavior
+AndroidX.Compose.Material3.IBottomAppBarScrollBehavior.FlingAnimationSpec.get -> AndroidX.Compose.Animation.Core.IDecayAnimationSpec?
 AndroidX.Compose.Material3.IBottomAppBarScrollBehavior.IsPinned.get -> bool
+AndroidX.Compose.Material3.IBottomAppBarScrollBehavior.NestedScrollConnection.get -> AndroidX.Compose.UI.Input.NestedScroll.INestedScrollConnection!
+AndroidX.Compose.Material3.IBottomAppBarScrollBehavior.SnapAnimationSpec.get -> AndroidX.Compose.Animation.Core.IAnimationSpec?
 AndroidX.Compose.Material3.IBottomAppBarScrollBehavior.State.get -> AndroidX.Compose.Material3.IBottomAppBarState!
 AndroidX.Compose.Material3.IBottomAppBarState
 AndroidX.Compose.Material3.IBottomAppBarState.CollapsedFraction.get -> float
@@ -367,15 +438,23 @@ AndroidX.Compose.Material3.IDateRangePickerState.SelectedStartDateMillis.get -> 
 AndroidX.Compose.Material3.IDateRangePickerState.SetSelection(Java.Lang.Long? p0, Java.Lang.Long? p1) -> void
 AndroidX.Compose.Material3.IDateRangePickerState.YearRange.get -> Kotlin.Ranges.IntRange!
 AndroidX.Compose.Material3.IExperimentalMaterial3Api
+AndroidX.Compose.Material3.IMultiChoiceSegmentedButtonRowScope
 AndroidX.Compose.Material3.INavigationDrawerItemColors
+AndroidX.Compose.Material3.INavigationDrawerItemColors.BadgeColor(bool p0, AndroidX.Compose.Runtime.IComposer? p1, int p2) -> AndroidX.Compose.Runtime.IState!
+AndroidX.Compose.Material3.INavigationDrawerItemColors.ContainerColor(bool p0, AndroidX.Compose.Runtime.IComposer? p1, int p2) -> AndroidX.Compose.Runtime.IState!
+AndroidX.Compose.Material3.INavigationDrawerItemColors.IconColor(bool p0, AndroidX.Compose.Runtime.IComposer? p1, int p2) -> AndroidX.Compose.Runtime.IState!
+AndroidX.Compose.Material3.INavigationDrawerItemColors.TextColor(bool p0, AndroidX.Compose.Runtime.IComposer? p1, int p2) -> AndroidX.Compose.Runtime.IState!
 AndroidX.Compose.Material3.ISearchBarScrollBehavior
+AndroidX.Compose.Material3.ISearchBarScrollBehavior.NestedScrollConnection.get -> AndroidX.Compose.UI.Input.NestedScroll.INestedScrollConnection!
 AndroidX.Compose.Material3.ISearchBarScrollBehavior.ScrollOffset.get -> float
 AndroidX.Compose.Material3.ISearchBarScrollBehavior.ScrollOffset.set -> void
 AndroidX.Compose.Material3.ISearchBarScrollBehavior.ScrollOffsetLimit.get -> float
 AndroidX.Compose.Material3.ISearchBarScrollBehavior.ScrollOffsetLimit.set -> void
+AndroidX.Compose.Material3.ISearchBarScrollBehavior.SearchBarScrollBehavior(AndroidX.Compose.UI.IModifier! p0) -> AndroidX.Compose.UI.IModifier!
 AndroidX.Compose.Material3.ISelectableDates
 AndroidX.Compose.Material3.ISelectableDates.IsSelectableDate(long utcTimeMillis) -> bool
 AndroidX.Compose.Material3.ISelectableDates.IsSelectableYear(int year) -> bool
+AndroidX.Compose.Material3.ISingleChoiceSegmentedButtonRowScope
 AndroidX.Compose.Material3.ISnackbarData
 AndroidX.Compose.Material3.ISnackbarData.Dismiss() -> void
 AndroidX.Compose.Material3.ISnackbarData.PerformAction() -> void
@@ -386,6 +465,8 @@ AndroidX.Compose.Material3.ISnackbarVisuals.Duration.get -> AndroidX.Compose.Mat
 AndroidX.Compose.Material3.ISnackbarVisuals.Message.get -> string!
 AndroidX.Compose.Material3.ISnackbarVisuals.WithDismissAction.get -> bool
 AndroidX.Compose.Material3.ITabIndicatorScope
+AndroidX.Compose.Material3.ITabIndicatorScope.TabIndicatorLayout(AndroidX.Compose.UI.IModifier! p0, Kotlin.Jvm.Functions.IFunction4! measure) -> AndroidX.Compose.UI.IModifier!
+AndroidX.Compose.Material3.ITabIndicatorScope.TabIndicatorOffset(AndroidX.Compose.UI.IModifier! p0, int selectedTabIndex, bool matchContentSize) -> AndroidX.Compose.UI.IModifier!
 AndroidX.Compose.Material3.ITextFieldLabelScope
 AndroidX.Compose.Material3.ITextFieldLabelScope.LabelMinimizedProgress.get -> float
 AndroidX.Compose.Material3.ITimePickerState
@@ -398,13 +479,20 @@ AndroidX.Compose.Material3.ITimePickerState.Selection.get -> int
 AndroidX.Compose.Material3.ITimePickerState.Selection.set -> void
 AndroidX.Compose.Material3.ITimePickerState.Set24hour(bool p0) -> void
 AndroidX.Compose.Material3.ITooltipScope
+AndroidX.Compose.Material3.ITooltipScope.ObtainAnchorBounds(AndroidX.Compose.UI.Layout.IMeasureScope! p0) -> AndroidX.Compose.UI.Layout.ILayoutCoordinates?
+AndroidX.Compose.Material3.ITooltipScope.ObtainPositionProvider() -> AndroidX.Compose.UI.Window.IPopupPositionProvider!
 AndroidX.Compose.Material3.ITooltipState
 AndroidX.Compose.Material3.ITooltipState.Dismiss() -> void
 AndroidX.Compose.Material3.ITooltipState.IsPersistent.get -> bool
 AndroidX.Compose.Material3.ITooltipState.IsVisible.get -> bool
 AndroidX.Compose.Material3.ITooltipState.OnDispose() -> void
+AndroidX.Compose.Material3.ITooltipState.Show(AndroidX.Compose.Foundation.MutatePriority! mutatePriority, Kotlin.Coroutines.IContinuation! p1) -> Java.Lang.Object?
+AndroidX.Compose.Material3.ITooltipState.Transition.get -> AndroidX.Compose.Animation.Core.MutableTransitionState!
 AndroidX.Compose.Material3.ITopAppBarScrollBehavior
+AndroidX.Compose.Material3.ITopAppBarScrollBehavior.FlingAnimationSpec.get -> AndroidX.Compose.Animation.Core.IDecayAnimationSpec?
 AndroidX.Compose.Material3.ITopAppBarScrollBehavior.IsPinned.get -> bool
+AndroidX.Compose.Material3.ITopAppBarScrollBehavior.NestedScrollConnection.get -> AndroidX.Compose.UI.Input.NestedScroll.INestedScrollConnection!
+AndroidX.Compose.Material3.ITopAppBarScrollBehavior.SnapAnimationSpec.get -> AndroidX.Compose.Animation.Core.IAnimationSpec?
 AndroidX.Compose.Material3.ITopAppBarScrollBehavior.State.get -> AndroidX.Compose.Material3.TopAppBarState!
 AndroidX.Compose.Material3.IWideNavigationRailState
 AndroidX.Compose.Material3.IWideNavigationRailState.Collapse(Kotlin.Coroutines.IContinuation! p0) -> Java.Lang.Object?
@@ -429,6 +517,9 @@ AndroidX.Compose.Material3.IconButtonDefaults.FilledTonalIconButtonColors(Androi
 AndroidX.Compose.Material3.IconButtonDefaults.FilledTonalIconButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.IconButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.FilledTonalIconToggleButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.FilledTonalIconToggleButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, long checkedContainerColor, long checkedContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
+AndroidX.Compose.Material3.IconButtonDefaults.GetFilledShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.IconButtonDefaults.GetOutlinedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.IconButtonDefaults.GetStandardShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.IconButtonDefaults.IconButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.IconButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.IconButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.IconButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.IconButtonVibrantColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.IconButtonColors!
@@ -442,12 +533,16 @@ AndroidX.Compose.Material3.IconButtonDefaults.IconToggleButtonColors(AndroidX.Co
 AndroidX.Compose.Material3.IconButtonDefaults.IconToggleButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, long checkedContainerColor, long checkedContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.IconToggleButtonVibrantColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.IconToggleButtonVibrantColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, long checkedContainerColor, long checkedContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
+AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconButtonBorder(bool enabled, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.IconButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.IconButtonColors!
+AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconButtonVibrantBorder(bool enabled, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconButtonVibrantColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.IconButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconButtonVibrantColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.IconButtonColors!
+AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconToggleButtonBorder(bool enabled, bool checked, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.BorderStroke?
 AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconToggleButtonColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconToggleButtonColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, long checkedContainerColor, long checkedContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
+AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconToggleButtonVibrantBorder(bool enabled, bool checked, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.BorderStroke?
 AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconToggleButtonVibrantColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
 AndroidX.Compose.Material3.IconButtonDefaults.OutlinedIconToggleButtonVibrantColors(long containerColor, long contentColor, long disabledContainerColor, long disabledContentColor, long checkedContainerColor, long checkedContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.IconToggleButtonColors!
 AndroidX.Compose.Material3.IconButtonKt
@@ -462,8 +557,10 @@ AndroidX.Compose.Material3.IconToggleButtonColors.DisabledContainerColor.get -> 
 AndroidX.Compose.Material3.IconToggleButtonColors.DisabledContentColor.get -> long
 AndroidX.Compose.Material3.InputChipDefaults
 AndroidX.Compose.Material3.InputChipDefaults.AvatarSize.get -> float
+AndroidX.Compose.Material3.InputChipDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.InputChipDefaults.Height.get -> float
 AndroidX.Compose.Material3.InputChipDefaults.IconSize.get -> float
+AndroidX.Compose.Material3.InputChipDefaults.InputChipBorder(bool enabled, bool selected, long borderColor, long selectedBorderColor, long disabledBorderColor, long disabledSelectedBorderColor, float borderWidth, float selectedBorderWidth, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.InputChipDefaults.InputChipColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.SelectableChipColors!
 AndroidX.Compose.Material3.InputChipDefaults.InputChipColors(long containerColor, long labelColor, long leadingIconColor, long trailingIconColor, long disabledContainerColor, long disabledLabelColor, long disabledLeadingIconColor, long disabledTrailingIconColor, long selectedContainerColor, long disabledSelectedContainerColor, long selectedLabelColor, long selectedLeadingIconColor, long selectedTrailingIconColor, AndroidX.Compose.Runtime.IComposer? _composer, int p14, int _changed, int _changed1) -> AndroidX.Compose.Material3.SelectableChipColors!
 AndroidX.Compose.Material3.InputChipDefaults.InputChipElevation(float elevation, float pressedElevation, float focusedElevation, float hoveredElevation, float draggedElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.SelectableChipElevation!
@@ -514,6 +611,7 @@ AndroidX.Compose.Material3.ListItemDefaults.Colors(long containerColor, long hea
 AndroidX.Compose.Material3.ListItemDefaults.Elevation.get -> float
 AndroidX.Compose.Material3.ListItemDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.ListItemDefaults.GetContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.ListItemDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.ListItemKt
 AndroidX.Compose.Material3.MaterialTheme
 AndroidX.Compose.Material3.MaterialTheme.GetColorScheme(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ColorScheme!
@@ -521,7 +619,9 @@ AndroidX.Compose.Material3.MaterialTheme.GetShapes(AndroidX.Compose.Runtime.ICom
 AndroidX.Compose.Material3.MaterialTheme.GetTypography(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.Typography!
 AndroidX.Compose.Material3.MaterialThemeKt
 AndroidX.Compose.Material3.MenuDefaults
+AndroidX.Compose.Material3.MenuDefaults.DropdownMenuItemContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
 AndroidX.Compose.Material3.MenuDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.MenuDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.MenuDefaults.ItemColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.MenuItemColors!
 AndroidX.Compose.Material3.MenuDefaults.ItemColors(long textColor, long leadingIconColor, long trailingIconColor, long disabledTextColor, long disabledLeadingIconColor, long disabledTrailingIconColor, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.MenuItemColors!
 AndroidX.Compose.Material3.MenuDefaults.ShadowElevation.get -> float
@@ -536,25 +636,34 @@ AndroidX.Compose.Material3.MenuItemColors.TextColor.get -> long
 AndroidX.Compose.Material3.MenuItemColors.TrailingIconColor.get -> long
 AndroidX.Compose.Material3.MenuKt
 AndroidX.Compose.Material3.ModalBottomSheetDefaults
+AndroidX.Compose.Material3.ModalBottomSheetDefaults.InvokeProperties(AndroidX.Compose.UI.Window.SecureFlagPolicy! securePolicy, bool isFocusable, bool shouldDismissOnBackPress) -> AndroidX.Compose.Material3.ModalBottomSheetProperties!
 AndroidX.Compose.Material3.ModalBottomSheetDefaults.Properties.get -> AndroidX.Compose.Material3.ModalBottomSheetProperties!
 AndroidX.Compose.Material3.ModalBottomSheetKt
 AndroidX.Compose.Material3.ModalBottomSheetKt.WhenMappings
 AndroidX.Compose.Material3.ModalBottomSheetProperties
 AndroidX.Compose.Material3.ModalBottomSheetProperties.ModalBottomSheetProperties() -> void
+AndroidX.Compose.Material3.ModalBottomSheetProperties.ModalBottomSheetProperties(AndroidX.Compose.UI.Window.SecureFlagPolicy! securePolicy, bool shouldDismissOnBackPress, bool shouldDismissOnClickOutside) -> void
+AndroidX.Compose.Material3.ModalBottomSheetProperties.ModalBottomSheetProperties(AndroidX.Compose.UI.Window.SecureFlagPolicy? securePolicy, bool shouldDismissOnBackPress) -> void
+AndroidX.Compose.Material3.ModalBottomSheetProperties.ModalBottomSheetProperties(bool isAppearanceLightStatusBars, bool isAppearanceLightNavigationBars, AndroidX.Compose.UI.Window.SecureFlagPolicy! securePolicy, bool shouldDismissOnBackPress, bool shouldDismissOnClickOutside) -> void
+AndroidX.Compose.Material3.ModalBottomSheetProperties.ModalBottomSheetProperties(bool isAppearanceLightStatusBars, bool isAppearanceLightNavigationBars, AndroidX.Compose.UI.Window.SecureFlagPolicy? securePolicy, bool shouldDismissOnBackPress) -> void
 AndroidX.Compose.Material3.ModalBottomSheetProperties.ModalBottomSheetProperties(bool shouldDismissOnBackPress) -> void
 AndroidX.Compose.Material3.ModalBottomSheetProperties.ModalBottomSheetProperties(bool shouldDismissOnBackPress, bool shouldDismissOnClickOutside) -> void
+AndroidX.Compose.Material3.ModalBottomSheetProperties.SecurePolicy.get -> AndroidX.Compose.UI.Window.SecureFlagPolicy!
 AndroidX.Compose.Material3.ModalBottomSheetProperties.ShouldDismissOnBackPress.get -> bool
 AndroidX.Compose.Material3.ModalBottomSheetProperties.ShouldDismissOnClickOutside() -> bool
 AndroidX.Compose.Material3.ModalBottomSheet_androidKt
 AndroidX.Compose.Material3.ModalWideNavigationRailProperties
 AndroidX.Compose.Material3.ModalWideNavigationRailProperties.ModalWideNavigationRailProperties() -> void
+AndroidX.Compose.Material3.ModalWideNavigationRailProperties.ModalWideNavigationRailProperties(AndroidX.Compose.UI.Window.SecureFlagPolicy! securePolicy, bool shouldDismissOnBackPress) -> void
 AndroidX.Compose.Material3.ModalWideNavigationRailProperties.ModalWideNavigationRailProperties(bool shouldDismissOnBackPress) -> void
+AndroidX.Compose.Material3.ModalWideNavigationRailProperties.SecurePolicy.get -> AndroidX.Compose.UI.Window.SecureFlagPolicy!
 AndroidX.Compose.Material3.ModalWideNavigationRailProperties.ShouldDismissOnBackPress.get -> bool
 AndroidX.Compose.Material3.MotionSchemeKt
 AndroidX.Compose.Material3.MotionSchemeKt.WhenMappings
 AndroidX.Compose.Material3.NavigationBarDefaults
 AndroidX.Compose.Material3.NavigationBarDefaults.Elevation.get -> float
 AndroidX.Compose.Material3.NavigationBarDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.NavigationBarDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.NavigationBarItemColors
 AndroidX.Compose.Material3.NavigationBarItemColors.Copy(long selectedIconColor, long selectedTextColor, long selectedIndicatorColor, long unselectedIconColor, long unselectedTextColor, long disabledIconColor, long disabledTextColor) -> AndroidX.Compose.Material3.NavigationBarItemColors!
 AndroidX.Compose.Material3.NavigationBarItemColors.DisabledIconColor.get -> long
@@ -570,6 +679,7 @@ AndroidX.Compose.Material3.NavigationBarItemDefaults.Colors(long selectedIconCol
 AndroidX.Compose.Material3.NavigationBarKt
 AndroidX.Compose.Material3.NavigationDrawerItemDefaults
 AndroidX.Compose.Material3.NavigationDrawerItemDefaults.Colors(long selectedContainerColor, long unselectedContainerColor, long selectedIconColor, long unselectedIconColor, long selectedTextColor, long unselectedTextColor, long selectedBadgeColor, long unselectedBadgeColor, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> AndroidX.Compose.Material3.INavigationDrawerItemColors!
+AndroidX.Compose.Material3.NavigationDrawerItemDefaults.ItemPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
 AndroidX.Compose.Material3.NavigationDrawerKt
 AndroidX.Compose.Material3.NavigationItemColors
 AndroidX.Compose.Material3.NavigationItemColors.Copy(long selectedIconColor, long selectedTextColor, long selectedIndicatorColor, long unselectedIconColor, long unselectedTextColor, long disabledIconColor, long disabledTextColor) -> AndroidX.Compose.Material3.NavigationItemColors!
@@ -589,6 +699,7 @@ AndroidX.Compose.Material3.NavigationItemIconPosition.Companion.Top__xw1Ddg.get 
 AndroidX.Compose.Material3.NavigationItemKt
 AndroidX.Compose.Material3.NavigationRailDefaults
 AndroidX.Compose.Material3.NavigationRailDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.NavigationRailDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.NavigationRailItemColors
 AndroidX.Compose.Material3.NavigationRailItemColors.Copy(long selectedIconColor, long selectedTextColor, long selectedIndicatorColor, long unselectedIconColor, long unselectedTextColor, long disabledIconColor, long disabledTextColor) -> AndroidX.Compose.Material3.NavigationRailItemColors!
 AndroidX.Compose.Material3.NavigationRailItemColors.DisabledIconColor.get -> long
@@ -604,8 +715,15 @@ AndroidX.Compose.Material3.NavigationRailItemDefaults.Colors(long selectedIconCo
 AndroidX.Compose.Material3.NavigationRailKt
 AndroidX.Compose.Material3.OutlinedTextFieldDefaults
 AndroidX.Compose.Material3.OutlinedTextFieldDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.TextFieldColors!
+AndroidX.Compose.Material3.OutlinedTextFieldDefaults.Colors(long focusedTextColor, long unfocusedTextColor, long disabledTextColor, long errorTextColor, long focusedContainerColor, long unfocusedContainerColor, long disabledContainerColor, long errorContainerColor, long cursorColor, long errorCursorColor, AndroidX.Compose.Foundation.Text.Selection.TextSelectionColors? selectionColors, long focusedBorderColor, long unfocusedBorderColor, long disabledBorderColor, long errorBorderColor, long focusedLeadingIconColor, long unfocusedLeadingIconColor, long disabledLeadingIconColor, long errorLeadingIconColor, long focusedTrailingIconColor, long unfocusedTrailingIconColor, long disabledTrailingIconColor, long errorTrailingIconColor, long focusedLabelColor, long unfocusedLabelColor, long disabledLabelColor, long errorLabelColor, long focusedPlaceholderColor, long unfocusedPlaceholderColor, long disabledPlaceholderColor, long errorPlaceholderColor, long focusedSupportingTextColor, long unfocusedSupportingTextColor, long disabledSupportingTextColor, long errorSupportingTextColor, long focusedPrefixColor, long unfocusedPrefixColor, long disabledPrefixColor, long errorPrefixColor, long focusedSuffixColor, long unfocusedSuffixColor, long disabledSuffixColor, long errorSuffixColor, AndroidX.Compose.Runtime.IComposer? _composer, int p44, int p45, int _changed, int _changed1, int _changed2, int _changed3, int _changed4) -> AndroidX.Compose.Material3.TextFieldColors!
+AndroidX.Compose.Material3.OutlinedTextFieldDefaults.Container(bool enabled, bool isError, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.UI.Graphics.IShape? shape, float focusedBorderThickness, float unfocusedBorderThickness, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+AndroidX.Compose.Material3.OutlinedTextFieldDefaults.ContainerBox(bool enabled, bool isError, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.UI.Graphics.IShape? shape, float focusedBorderThickness, float unfocusedBorderThickness, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+AndroidX.Compose.Material3.OutlinedTextFieldDefaults.ContentPadding(float start, float top, float end, float bottom) -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.OutlinedTextFieldDefaults.DecorationBox(string! value, Kotlin.Jvm.Functions.IFunction2! innerTextField, bool enabled, bool singleLine, AndroidX.Compose.UI.Text.Input.IVisualTransformation! visualTransformation, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, bool isError, Kotlin.Jvm.Functions.IFunction2? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, Kotlin.Jvm.Functions.IFunction2? container, AndroidX.Compose.Runtime.IComposer? _composer, int p18, int _changed, int _changed1) -> void
+AndroidX.Compose.Material3.OutlinedTextFieldDefaults.Decorator(AndroidX.Compose.Foundation.Text.Input.TextFieldState! state, bool enabled, AndroidX.Compose.Foundation.Text.Input.ITextFieldLineLimits! lineLimits, AndroidX.Compose.Foundation.Text.Input.IOutputTransformation? outputTransformation, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, AndroidX.Compose.Material3.TextFieldLabelPosition? labelPosition, Kotlin.Jvm.Functions.IFunction3? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, Kotlin.Jvm.Functions.IFunction2? container, AndroidX.Compose.Runtime.IComposer? _composer, int p18, int _changed, int _changed1) -> AndroidX.Compose.Foundation.Text.Input.ITextFieldDecorator!
 AndroidX.Compose.Material3.OutlinedTextFieldDefaults.FocusedBorderThickness.get -> float
 AndroidX.Compose.Material3.OutlinedTextFieldDefaults.GetDefaultOutlinedTextFieldColors(AndroidX.Compose.Material3.ColorScheme! _this_defaultOutlinedTextFieldColors, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.TextFieldColors!
+AndroidX.Compose.Material3.OutlinedTextFieldDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.OutlinedTextFieldDefaults.MinHeight.get -> float
 AndroidX.Compose.Material3.OutlinedTextFieldDefaults.MinWidth.get -> float
 AndroidX.Compose.Material3.OutlinedTextFieldDefaults.UnfocusedBorderThickness.get -> float
@@ -615,6 +733,7 @@ AndroidX.Compose.Material3.ProgressIndicatorDefaults.CircularDeterminateStrokeCa
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.CircularIndeterminateStrokeCap.get -> int
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.CircularIndicatorTrackGapSize.get -> float
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.CircularStrokeWidth.get -> float
+AndroidX.Compose.Material3.ProgressIndicatorDefaults.DrawStopIndicator(AndroidX.Compose.UI.Graphics.Drawscope.IDrawScope! drawScope, float stopSize, long color, int strokeCap) -> void
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.GetCircularColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.GetCircularDeterminateTrackColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.GetCircularIndeterminateTrackColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
@@ -624,6 +743,7 @@ AndroidX.Compose.Material3.ProgressIndicatorDefaults.GetLinearTrackColor(Android
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.LinearIndicatorTrackGapSize.get -> float
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.LinearStrokeCap.get -> int
 AndroidX.Compose.Material3.ProgressIndicatorDefaults.LinearTrackStopIndicatorSize.get -> float
+AndroidX.Compose.Material3.ProgressIndicatorDefaults.ProgressAnimationSpec.get -> AndroidX.Compose.Animation.Core.SpringSpec!
 AndroidX.Compose.Material3.ProgressIndicatorKt
 AndroidX.Compose.Material3.PullToRefresh.IPullToRefreshState
 AndroidX.Compose.Material3.PullToRefresh.IPullToRefreshState.AnimateToHidden(Kotlin.Coroutines.IContinuation! p0) -> Java.Lang.Object?
@@ -636,9 +756,13 @@ AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.Elevation.get -> 
 AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.GetIndicatorColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.GetIndicatorContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.Indicator(AndroidX.Compose.Material3.PullToRefresh.IPullToRefreshState! state, bool isRefreshing, AndroidX.Compose.UI.IModifier? modifier, long containerColor, long color, float maxDistance, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
+AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.IndicatorBox(AndroidX.Compose.Material3.PullToRefresh.IPullToRefreshState! state, bool isRefreshing, AndroidX.Compose.UI.IModifier? modifier, float maxDistance, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, float elevation, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
 AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.IndicatorMaxDistance.get -> float
+AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.IndicatorShape.get -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.LoadingIndicatorElevation.get -> float
 AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.PositionalThreshold.get -> float
+AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.Shape.get -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.PullToRefresh.PullToRefreshKt
 AndroidX.Compose.Material3.RadioButtonColors
 AndroidX.Compose.Material3.RadioButtonColors.Copy(long selectedColor, long unselectedColor, long disabledSelectedColor, long disabledUnselectedColor) -> AndroidX.Compose.Material3.RadioButtonColors!
@@ -673,6 +797,7 @@ AndroidX.Compose.Material3.RippleConfiguration.Color.get -> long
 AndroidX.Compose.Material3.RippleDefaults
 AndroidX.Compose.Material3.RippleKt
 AndroidX.Compose.Material3.ScaffoldDefaults
+AndroidX.Compose.Material3.ScaffoldDefaults.GetContentWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.ScaffoldKt
 AndroidX.Compose.Material3.SearchBarColors
 AndroidX.Compose.Material3.SearchBarColors.ContainerColor.get -> long
@@ -681,6 +806,16 @@ AndroidX.Compose.Material3.SearchBarColors.InputFieldColors.get -> AndroidX.Comp
 AndroidX.Compose.Material3.SearchBarDefaults
 AndroidX.Compose.Material3.SearchBarDefaults.Colors(long containerColor, long dividerColor, AndroidX.Compose.Material3.TextFieldColors? inputFieldColors, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.SearchBarColors!
 AndroidX.Compose.Material3.SearchBarDefaults.Elevation.get -> float
+AndroidX.Compose.Material3.SearchBarDefaults.EnterAlwaysSearchBarScrollBehavior(float initialOffset, float initialOffsetLimit, Kotlin.Jvm.Functions.IFunction0? canScroll, AndroidX.Compose.Animation.Core.IAnimationSpec? snapAnimationSpec, AndroidX.Compose.Animation.Core.IDecayAnimationSpec? flingAnimationSpec, bool reverseLayout, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.ISearchBarScrollBehavior!
+AndroidX.Compose.Material3.SearchBarDefaults.GetDockedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.SearchBarDefaults.GetFullScreenShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.SearchBarDefaults.GetFullScreenWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
+AndroidX.Compose.Material3.SearchBarDefaults.GetInputFieldShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.SearchBarDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
+AndroidX.Compose.Material3.SearchBarDefaults.InputField(AndroidX.Compose.Foundation.Text.Input.TextFieldState! state, Kotlin.Jvm.Functions.IFunction1! onSearch, bool expanded, Kotlin.Jvm.Functions.IFunction1! onExpandedChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, bool readOnly, AndroidX.Compose.UI.Text.TextStyle? textStyle, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, AndroidX.Compose.Foundation.Text.Input.IInputTransformation? inputTransformation, AndroidX.Compose.Foundation.Text.Input.IOutputTransformation? outputTransformation, AndroidX.Compose.Foundation.ScrollState? scrollState, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p20, int _changed, int _changed1) -> void
+AndroidX.Compose.Material3.SearchBarDefaults.InputField(AndroidX.Compose.Foundation.Text.Input.TextFieldState! textFieldState, AndroidX.Compose.Material3.SearchBarState! searchBarState, Kotlin.Jvm.Functions.IFunction1! onSearch, AndroidX.Compose.UI.IModifier? modifier, bool enabled, bool readOnly, AndroidX.Compose.UI.Text.TextStyle? textStyle, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, AndroidX.Compose.Foundation.Text.Input.IInputTransformation? inputTransformation, AndroidX.Compose.Foundation.Text.Input.IOutputTransformation? outputTransformation, AndroidX.Compose.Foundation.ScrollState? scrollState, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p19, int _changed, int _changed1) -> void
+AndroidX.Compose.Material3.SearchBarDefaults.InputField(string! query, Kotlin.Jvm.Functions.IFunction1! onQueryChange, Kotlin.Jvm.Functions.IFunction1! onSearch, bool expanded, Kotlin.Jvm.Functions.IFunction1! onExpandedChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
+AndroidX.Compose.Material3.SearchBarDefaults.InputFieldColors(long focusedTextColor, long unfocusedTextColor, long disabledTextColor, long cursorColor, AndroidX.Compose.Foundation.Text.Selection.TextSelectionColors? selectionColors, long focusedLeadingIconColor, long unfocusedLeadingIconColor, long disabledLeadingIconColor, long focusedTrailingIconColor, long unfocusedTrailingIconColor, long disabledTrailingIconColor, long focusedPlaceholderColor, long unfocusedPlaceholderColor, long disabledPlaceholderColor, long focusedPrefixColor, long unfocusedPrefixColor, long disabledPrefixColor, long focusedSuffixColor, long unfocusedSuffixColor, long disabledSuffixColor, long focusedContainerColor, long unfocusedContainerColor, long disabledContainerColor, AndroidX.Compose.Runtime.IComposer? _composer, int p24, int _changed, int _changed1, int _changed2) -> AndroidX.Compose.Material3.TextFieldColors!
 AndroidX.Compose.Material3.SearchBarDefaults.InputFieldHeight.get -> float
 AndroidX.Compose.Material3.SearchBarDefaults.ShadowElevation.get -> float
 AndroidX.Compose.Material3.SearchBarDefaults.TonalElevation.get -> float
@@ -688,10 +823,13 @@ AndroidX.Compose.Material3.SearchBarKt
 AndroidX.Compose.Material3.SearchBarState
 AndroidX.Compose.Material3.SearchBarState.AnimateToCollapsed(Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
 AndroidX.Compose.Material3.SearchBarState.AnimateToExpanded(Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
+AndroidX.Compose.Material3.SearchBarState.CollapsedCoords.get -> AndroidX.Compose.UI.Layout.ILayoutCoordinates?
+AndroidX.Compose.Material3.SearchBarState.CollapsedCoords.set -> void
 AndroidX.Compose.Material3.SearchBarState.Companion
 AndroidX.Compose.Material3.SearchBarState.CurrentValue.get -> AndroidX.Compose.Material3.SearchBarValue!
 AndroidX.Compose.Material3.SearchBarState.IsAnimating.get -> bool
 AndroidX.Compose.Material3.SearchBarState.Progress.get -> float
+AndroidX.Compose.Material3.SearchBarState.SearchBarState(AndroidX.Compose.Material3.SearchBarValue! initialValue, AndroidX.Compose.Animation.Core.IAnimationSpec! animationSpecForExpand, AndroidX.Compose.Animation.Core.IAnimationSpec! animationSpecForCollapse) -> void
 AndroidX.Compose.Material3.SearchBarState.SnapTo(float fraction, Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
 AndroidX.Compose.Material3.SearchBarState.TargetValue.get -> AndroidX.Compose.Material3.SearchBarValue!
 AndroidX.Compose.Material3.SearchBarValue
@@ -713,11 +851,15 @@ AndroidX.Compose.Material3.SegmentedButtonColors.InactiveContainerColor.get -> l
 AndroidX.Compose.Material3.SegmentedButtonColors.InactiveContentColor.get -> long
 AndroidX.Compose.Material3.SegmentedButtonDefaults
 AndroidX.Compose.Material3.SegmentedButtonDefaults.ActiveIcon(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> void
+AndroidX.Compose.Material3.SegmentedButtonDefaults.BorderStroke(long color, float width) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.SegmentedButtonDefaults.BorderWidth.get -> float
 AndroidX.Compose.Material3.SegmentedButtonDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.SegmentedButtonColors!
 AndroidX.Compose.Material3.SegmentedButtonDefaults.Colors(long activeContainerColor, long activeContentColor, long activeBorderColor, long inactiveContainerColor, long inactiveContentColor, long inactiveBorderColor, long disabledActiveContainerColor, long disabledActiveContentColor, long disabledActiveBorderColor, long disabledInactiveContainerColor, long disabledInactiveContentColor, long disabledInactiveBorderColor, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> AndroidX.Compose.Material3.SegmentedButtonColors!
+AndroidX.Compose.Material3.SegmentedButtonDefaults.ContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.SegmentedButtonDefaults.GetBaseShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
 AndroidX.Compose.Material3.SegmentedButtonDefaults.Icon(bool active, Kotlin.Jvm.Functions.IFunction2? activeContent, Kotlin.Jvm.Functions.IFunction2? inactiveContent, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
 AndroidX.Compose.Material3.SegmentedButtonDefaults.IconSize.get -> float
+AndroidX.Compose.Material3.SegmentedButtonDefaults.ItemShape(int p0, int index, AndroidX.Compose.Foundation.Shape.CornerBasedShape? baseShape, AndroidX.Compose.Runtime.IComposer? _composer, int count, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.SegmentedButtonKt
 AndroidX.Compose.Material3.SelectableChipColors
 AndroidX.Compose.Material3.SelectableChipColors.Copy(long containerColor, long labelColor, long leadingIconColor, long trailingIconColor, long disabledContainerColor, long disabledLabelColor, long disabledLeadingIconColor, long disabledTrailingIconColor, long selectedContainerColor, long disabledSelectedContainerColor, long selectedLabelColor, long selectedLeadingIconColor, long selectedTrailingIconColor) -> AndroidX.Compose.Material3.SelectableChipColors!
@@ -729,8 +871,20 @@ AndroidX.Compose.Material3.SelectableChipElevation.FocusedElevation.get -> float
 AndroidX.Compose.Material3.SelectableChipElevation.HoveredElevation.get -> float
 AndroidX.Compose.Material3.SelectableChipElevation.PressedElevation.get -> float
 AndroidX.Compose.Material3.ShapeDefaults
+AndroidX.Compose.Material3.ShapeDefaults.ExtraLarge.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
+AndroidX.Compose.Material3.ShapeDefaults.ExtraSmall.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
+AndroidX.Compose.Material3.ShapeDefaults.Large.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
+AndroidX.Compose.Material3.ShapeDefaults.Medium.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
+AndroidX.Compose.Material3.ShapeDefaults.Small.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
 AndroidX.Compose.Material3.Shapes
+AndroidX.Compose.Material3.Shapes.Copy(AndroidX.Compose.Foundation.Shape.CornerBasedShape! extraSmall, AndroidX.Compose.Foundation.Shape.CornerBasedShape! small, AndroidX.Compose.Foundation.Shape.CornerBasedShape! medium, AndroidX.Compose.Foundation.Shape.CornerBasedShape! large, AndroidX.Compose.Foundation.Shape.CornerBasedShape! extraLarge) -> AndroidX.Compose.Material3.Shapes!
+AndroidX.Compose.Material3.Shapes.ExtraLarge.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
+AndroidX.Compose.Material3.Shapes.ExtraSmall.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
+AndroidX.Compose.Material3.Shapes.Large.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
+AndroidX.Compose.Material3.Shapes.Medium.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
 AndroidX.Compose.Material3.Shapes.Shapes() -> void
+AndroidX.Compose.Material3.Shapes.Shapes(AndroidX.Compose.Foundation.Shape.CornerBasedShape! extraSmall, AndroidX.Compose.Foundation.Shape.CornerBasedShape! small, AndroidX.Compose.Foundation.Shape.CornerBasedShape! medium, AndroidX.Compose.Foundation.Shape.CornerBasedShape! large, AndroidX.Compose.Foundation.Shape.CornerBasedShape! extraLarge) -> void
+AndroidX.Compose.Material3.Shapes.Small.get -> AndroidX.Compose.Foundation.Shape.CornerBasedShape!
 AndroidX.Compose.Material3.ShapesKt
 AndroidX.Compose.Material3.ShapesKt.WhenMappings
 AndroidX.Compose.Material3.SheetDefaultsKt
@@ -745,6 +899,7 @@ AndroidX.Compose.Material3.SheetState.IsAnimationRunning.get -> bool
 AndroidX.Compose.Material3.SheetState.IsVisible.get -> bool
 AndroidX.Compose.Material3.SheetState.PartialExpand(Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
 AndroidX.Compose.Material3.SheetState.RequireOffset() -> float
+AndroidX.Compose.Material3.SheetState.SheetState(bool skipPartiallyExpanded, AndroidX.Compose.UI.Unit.IDensity? density, AndroidX.Compose.Material3.SheetValue? initialValue, Kotlin.Jvm.Functions.IFunction1? confirmValueChange, bool skipHiddenState) -> void
 AndroidX.Compose.Material3.SheetState.SheetState(bool skipPartiallyExpanded, Kotlin.Jvm.Functions.IFunction0! positionalThreshold, Kotlin.Jvm.Functions.IFunction0! velocityThreshold, AndroidX.Compose.Material3.SheetValue! initialValue, Kotlin.Jvm.Functions.IFunction1! confirmValueChange, bool skipHiddenState) -> void
 AndroidX.Compose.Material3.SheetState.Show(Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
 AndroidX.Compose.Material3.SheetState.TargetValue.get -> AndroidX.Compose.Material3.SheetValue!
@@ -757,6 +912,7 @@ AndroidX.Compose.Material3.ShortNavigationBarDefaults
 AndroidX.Compose.Material3.ShortNavigationBarDefaults.Arrangement.get -> int
 AndroidX.Compose.Material3.ShortNavigationBarDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.ShortNavigationBarDefaults.GetContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.ShortNavigationBarDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.ShortNavigationBarItemDefaults
 AndroidX.Compose.Material3.ShortNavigationBarItemDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.NavigationItemColors!
 AndroidX.Compose.Material3.ShortNavigationBarItemDefaults.Colors(long selectedIconColor, long selectedTextColor, long selectedIndicatorColor, long unselectedIconColor, long unselectedTextColor, long disabledIconColor, long disabledTextColor, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> AndroidX.Compose.Material3.NavigationItemColors!
@@ -776,7 +932,10 @@ AndroidX.Compose.Material3.SliderColors.ThumbColor.get -> long
 AndroidX.Compose.Material3.SliderDefaults
 AndroidX.Compose.Material3.SliderDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.SliderColors!
 AndroidX.Compose.Material3.SliderDefaults.Colors(long thumbColor, long activeTrackColor, long activeTickColor, long inactiveTrackColor, long inactiveTickColor, long disabledThumbColor, long disabledActiveTrackColor, long disabledActiveTickColor, long disabledInactiveTrackColor, long disabledInactiveTickColor, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed, int _changed1) -> AndroidX.Compose.Material3.SliderColors!
+AndroidX.Compose.Material3.SliderDefaults.DrawStopIndicator(AndroidX.Compose.UI.Graphics.Drawscope.IDrawScope! _this_drawStopIndicator_u2dx3O1jOs, long offset, float size, long color) -> void
+AndroidX.Compose.Material3.SliderDefaults.Thumb(AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource! interactionSource, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.SliderColors? colors, bool enabled, long thumbSize, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> void
 AndroidX.Compose.Material3.SliderDefaults.TickSize.get -> float
+AndroidX.Compose.Material3.SliderDefaults.Track(AndroidX.Compose.Material3.SliderPositions! sliderPositions, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.SliderColors? colors, bool enabled, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
 AndroidX.Compose.Material3.SliderDefaults.TrackStopIndicatorSize.get -> float
 AndroidX.Compose.Material3.SliderKt
 AndroidX.Compose.Material3.SliderPositions
@@ -784,12 +943,31 @@ AndroidX.Compose.Material3.SliderPositions.ActiveRange.get -> Kotlin.Ranges.IClo
 AndroidX.Compose.Material3.SliderPositions.GetTickFractions() -> float[]!
 AndroidX.Compose.Material3.SliderPositions.SliderPositions() -> void
 AndroidX.Compose.Material3.SliderPositions.SliderPositions(Kotlin.Ranges.IClosedFloatingPointRange! initialActiveRange, float[]! initialTickFractions) -> void
+AndroidX.Compose.Material3.SliderState
+AndroidX.Compose.Material3.SliderState.CoercedValueAsFraction.get -> float
+AndroidX.Compose.Material3.SliderState.Companion
+AndroidX.Compose.Material3.SliderState.DispatchRawDelta(float delta) -> void
+AndroidX.Compose.Material3.SliderState.Drag(AndroidX.Compose.Foundation.MutatePriority! dragPriority, Kotlin.Jvm.Functions.IFunction2! block, Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
+AndroidX.Compose.Material3.SliderState.IsDragging.get -> bool
+AndroidX.Compose.Material3.SliderState.OnValueChange.get -> Kotlin.Jvm.Functions.IFunction1?
+AndroidX.Compose.Material3.SliderState.OnValueChange.set -> void
+AndroidX.Compose.Material3.SliderState.OnValueChangeFinished.get -> Kotlin.Jvm.Functions.IFunction0?
+AndroidX.Compose.Material3.SliderState.OnValueChangeFinished.set -> void
+AndroidX.Compose.Material3.SliderState.SetShouldAutoSnap(bool value) -> void
+AndroidX.Compose.Material3.SliderState.ShouldAutoSnap() -> bool
+AndroidX.Compose.Material3.SliderState.SliderState() -> void
+AndroidX.Compose.Material3.SliderState.SliderState(float value, int steps, Kotlin.Jvm.Functions.IFunction0? onValueChangeFinished, Kotlin.Ranges.IClosedFloatingPointRange! valueRange) -> void
+AndroidX.Compose.Material3.SliderState.Steps.get -> int
+AndroidX.Compose.Material3.SliderState.Value.get -> float
+AndroidX.Compose.Material3.SliderState.Value.set -> void
+AndroidX.Compose.Material3.SliderState.ValueRange.get -> Kotlin.Ranges.IClosedFloatingPointRange!
 AndroidX.Compose.Material3.SnackbarDefaults
 AndroidX.Compose.Material3.SnackbarDefaults.GetActionColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.SnackbarDefaults.GetActionContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.SnackbarDefaults.GetColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.SnackbarDefaults.GetContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.SnackbarDefaults.GetDismissActionContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.SnackbarDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.SnackbarDuration
 AndroidX.Compose.Material3.SnackbarHostKt
 AndroidX.Compose.Material3.SnackbarHostKt.WhenMappings
@@ -804,8 +982,10 @@ AndroidX.Compose.Material3.SuggestionChipDefaults
 AndroidX.Compose.Material3.SuggestionChipDefaults.ElevatedSuggestionChipColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ChipColors!
 AndroidX.Compose.Material3.SuggestionChipDefaults.ElevatedSuggestionChipColors(long containerColor, long labelColor, long iconContentColor, long disabledContainerColor, long disabledLabelColor, long disabledIconContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.ChipColors!
 AndroidX.Compose.Material3.SuggestionChipDefaults.ElevatedSuggestionChipElevation(float elevation, float pressedElevation, float focusedElevation, float hoveredElevation, float draggedElevation, float disabledElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.ChipElevation!
+AndroidX.Compose.Material3.SuggestionChipDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.SuggestionChipDefaults.Height.get -> float
 AndroidX.Compose.Material3.SuggestionChipDefaults.IconSize.get -> float
+AndroidX.Compose.Material3.SuggestionChipDefaults.SuggestionChipBorder(bool enabled, long borderColor, long disabledBorderColor, float borderWidth, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Foundation.BorderStroke!
 AndroidX.Compose.Material3.SuggestionChipDefaults.SuggestionChipBorder(long borderColor, long disabledBorderColor, float borderWidth, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.ChipBorder!
 AndroidX.Compose.Material3.SuggestionChipDefaults.SuggestionChipColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.ChipColors!
 AndroidX.Compose.Material3.SuggestionChipDefaults.SuggestionChipColors(long containerColor, long labelColor, long iconContentColor, long disabledContainerColor, long disabledLabelColor, long disabledIconContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> AndroidX.Compose.Material3.ChipColors!
@@ -824,6 +1004,7 @@ AndroidX.Compose.Material3.SwipeToDismissBoxState.RequireOffset() -> float
 AndroidX.Compose.Material3.SwipeToDismissBoxState.Reset(Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
 AndroidX.Compose.Material3.SwipeToDismissBoxState.SettledValue.get -> AndroidX.Compose.Material3.SwipeToDismissBoxValue!
 AndroidX.Compose.Material3.SwipeToDismissBoxState.SnapTo(AndroidX.Compose.Material3.SwipeToDismissBoxValue! targetValue, Kotlin.Coroutines.IContinuation! _completion) -> Java.Lang.Object?
+AndroidX.Compose.Material3.SwipeToDismissBoxState.SwipeToDismissBoxState(AndroidX.Compose.Material3.SwipeToDismissBoxValue! initialValue, AndroidX.Compose.UI.Unit.IDensity! density, Kotlin.Jvm.Functions.IFunction1! confirmValueChange, Kotlin.Jvm.Functions.IFunction1! positionalThreshold) -> void
 AndroidX.Compose.Material3.SwipeToDismissBoxState.SwipeToDismissBoxState(AndroidX.Compose.Material3.SwipeToDismissBoxValue! initialValue, Kotlin.Jvm.Functions.IFunction1! positionalThreshold) -> void
 AndroidX.Compose.Material3.SwipeToDismissBoxState.TargetValue.get -> AndroidX.Compose.Material3.SwipeToDismissBoxValue!
 AndroidX.Compose.Material3.SwipeToDismissBoxValue
@@ -863,10 +1044,15 @@ AndroidX.Compose.Material3.TabRowDefaults.GetPrimaryContainerColor(AndroidX.Comp
 AndroidX.Compose.Material3.TabRowDefaults.GetPrimaryContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.TabRowDefaults.GetSecondaryContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 AndroidX.Compose.Material3.TabRowDefaults.GetSecondaryContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.TabRowDefaults.Indicator(AndroidX.Compose.UI.IModifier? modifier, float height, long color, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
+AndroidX.Compose.Material3.TabRowDefaults.PrimaryIndicator(AndroidX.Compose.UI.IModifier? modifier, float width, float height, long color, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> void
 AndroidX.Compose.Material3.TabRowDefaults.ScrollableTabRowEdgeStartPadding.get -> float
 AndroidX.Compose.Material3.TabRowDefaults.ScrollableTabRowMinTabWidth.get -> float
+AndroidX.Compose.Material3.TabRowDefaults.SecondaryIndicator(AndroidX.Compose.UI.IModifier? modifier, float height, long color, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
+AndroidX.Compose.Material3.TabRowDefaults.TabIndicatorOffset(AndroidX.Compose.UI.IModifier! _this_tabIndicatorOffset, AndroidX.Compose.Material3.TabPosition! currentTabPosition) -> AndroidX.Compose.UI.IModifier!
 AndroidX.Compose.Material3.TabRowKt
 AndroidX.Compose.Material3.TextFieldColors
+AndroidX.Compose.Material3.TextFieldColors.Copy(long focusedTextColor, long unfocusedTextColor, long disabledTextColor, long errorTextColor, long focusedContainerColor, long unfocusedContainerColor, long disabledContainerColor, long errorContainerColor, long cursorColor, long errorCursorColor, AndroidX.Compose.Foundation.Text.Selection.TextSelectionColors? textSelectionColors, long focusedIndicatorColor, long unfocusedIndicatorColor, long disabledIndicatorColor, long errorIndicatorColor, long focusedLeadingIconColor, long unfocusedLeadingIconColor, long disabledLeadingIconColor, long errorLeadingIconColor, long focusedTrailingIconColor, long unfocusedTrailingIconColor, long disabledTrailingIconColor, long errorTrailingIconColor, long focusedLabelColor, long unfocusedLabelColor, long disabledLabelColor, long errorLabelColor, long focusedPlaceholderColor, long unfocusedPlaceholderColor, long disabledPlaceholderColor, long errorPlaceholderColor, long focusedSupportingTextColor, long unfocusedSupportingTextColor, long disabledSupportingTextColor, long errorSupportingTextColor, long focusedPrefixColor, long unfocusedPrefixColor, long disabledPrefixColor, long errorPrefixColor, long focusedSuffixColor, long unfocusedSuffixColor, long disabledSuffixColor, long errorSuffixColor) -> AndroidX.Compose.Material3.TextFieldColors!
 AndroidX.Compose.Material3.TextFieldColors.CursorColor.get -> long
 AndroidX.Compose.Material3.TextFieldColors.DisabledContainerColor.get -> long
 AndroidX.Compose.Material3.TextFieldColors.DisabledIndicatorColor.get -> long
@@ -899,6 +1085,7 @@ AndroidX.Compose.Material3.TextFieldColors.FocusedSuffixColor.get -> long
 AndroidX.Compose.Material3.TextFieldColors.FocusedSupportingTextColor.get -> long
 AndroidX.Compose.Material3.TextFieldColors.FocusedTextColor.get -> long
 AndroidX.Compose.Material3.TextFieldColors.FocusedTrailingIconColor.get -> long
+AndroidX.Compose.Material3.TextFieldColors.TextSelectionColors.get -> AndroidX.Compose.Foundation.Text.Selection.TextSelectionColors!
 AndroidX.Compose.Material3.TextFieldColors.UnfocusedContainerColor.get -> long
 AndroidX.Compose.Material3.TextFieldColors.UnfocusedIndicatorColor.get -> long
 AndroidX.Compose.Material3.TextFieldColors.UnfocusedLabelColor.get -> long
@@ -911,19 +1098,38 @@ AndroidX.Compose.Material3.TextFieldColors.UnfocusedTextColor.get -> long
 AndroidX.Compose.Material3.TextFieldColors.UnfocusedTrailingIconColor.get -> long
 AndroidX.Compose.Material3.TextFieldDefaults
 AndroidX.Compose.Material3.TextFieldDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.TextFieldColors!
+AndroidX.Compose.Material3.TextFieldDefaults.Colors(long focusedTextColor, long unfocusedTextColor, long disabledTextColor, long errorTextColor, long focusedContainerColor, long unfocusedContainerColor, long disabledContainerColor, long errorContainerColor, long cursorColor, long errorCursorColor, AndroidX.Compose.Foundation.Text.Selection.TextSelectionColors? selectionColors, long focusedIndicatorColor, long unfocusedIndicatorColor, long disabledIndicatorColor, long errorIndicatorColor, long focusedLeadingIconColor, long unfocusedLeadingIconColor, long disabledLeadingIconColor, long errorLeadingIconColor, long focusedTrailingIconColor, long unfocusedTrailingIconColor, long disabledTrailingIconColor, long errorTrailingIconColor, long focusedLabelColor, long unfocusedLabelColor, long disabledLabelColor, long errorLabelColor, long focusedPlaceholderColor, long unfocusedPlaceholderColor, long disabledPlaceholderColor, long errorPlaceholderColor, long focusedSupportingTextColor, long unfocusedSupportingTextColor, long disabledSupportingTextColor, long errorSupportingTextColor, long focusedPrefixColor, long unfocusedPrefixColor, long disabledPrefixColor, long errorPrefixColor, long focusedSuffixColor, long unfocusedSuffixColor, long disabledSuffixColor, long errorSuffixColor, AndroidX.Compose.Runtime.IComposer? _composer, int p44, int p45, int _changed, int _changed1, int _changed2, int _changed3, int _changed4) -> AndroidX.Compose.Material3.TextFieldColors!
+AndroidX.Compose.Material3.TextFieldDefaults.Container(bool enabled, bool isError, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.UI.Graphics.IShape? shape, float focusedIndicatorLineThickness, float unfocusedIndicatorLineThickness, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+AndroidX.Compose.Material3.TextFieldDefaults.ContainerBox(bool enabled, bool isError, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, AndroidX.Compose.Material3.TextFieldColors! colors, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> void
+AndroidX.Compose.Material3.TextFieldDefaults.ContentPaddingWithLabel(float start, float end, float top, float bottom) -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.TextFieldDefaults.ContentPaddingWithoutLabel(float start, float top, float end, float bottom) -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.TextFieldDefaults.DecorationBox(string! value, Kotlin.Jvm.Functions.IFunction2! innerTextField, bool enabled, bool singleLine, AndroidX.Compose.UI.Text.Input.IVisualTransformation! visualTransformation, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, bool isError, Kotlin.Jvm.Functions.IFunction2? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, Kotlin.Jvm.Functions.IFunction2? container, AndroidX.Compose.Runtime.IComposer? _composer, int p19, int _changed, int _changed1) -> void
+AndroidX.Compose.Material3.TextFieldDefaults.Decorator(AndroidX.Compose.Foundation.Text.Input.TextFieldState! state, bool enabled, AndroidX.Compose.Foundation.Text.Input.ITextFieldLineLimits! lineLimits, AndroidX.Compose.Foundation.Text.Input.IOutputTransformation? outputTransformation, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, AndroidX.Compose.Material3.TextFieldLabelPosition? labelPosition, Kotlin.Jvm.Functions.IFunction3? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, Kotlin.Jvm.Functions.IFunction2? container, AndroidX.Compose.Runtime.IComposer? _composer, int p18, int _changed, int _changed1) -> AndroidX.Compose.Foundation.Text.Input.ITextFieldDecorator!
 AndroidX.Compose.Material3.TextFieldDefaults.FocusedBorderThickness.get -> float
 AndroidX.Compose.Material3.TextFieldDefaults.FocusedIndicatorThickness.get -> float
+AndroidX.Compose.Material3.TextFieldDefaults.GetFilledShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.TextFieldDefaults.GetOutlinedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.TextFieldDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.TextFieldDefaults.IndicatorLine(AndroidX.Compose.UI.IModifier! _this_indicatorLine_u2dAWlRVLg, bool enabled, bool isError, AndroidX.Compose.Foundation.Interaction.IInteractionSource! interactionSource, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.UI.Graphics.IShape? textFieldShape, float focusedIndicatorLineThickness, float unfocusedIndicatorLineThickness) -> AndroidX.Compose.UI.IModifier!
 AndroidX.Compose.Material3.TextFieldDefaults.MinHeight.get -> float
 AndroidX.Compose.Material3.TextFieldDefaults.MinWidth.get -> float
+AndroidX.Compose.Material3.TextFieldDefaults.OutlinedTextFieldPadding(float start, float top, float end, float bottom) -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.TextFieldDefaults.TextFieldWithLabelPadding(float start, float end, float top, float bottom) -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+AndroidX.Compose.Material3.TextFieldDefaults.TextFieldWithoutLabelPadding(float start, float top, float end, float bottom) -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
 AndroidX.Compose.Material3.TextFieldDefaults.UnfocusedBorderThickness.get -> float
 AndroidX.Compose.Material3.TextFieldDefaults.UnfocusedIndicatorThickness.get -> float
 AndroidX.Compose.Material3.TextFieldKt
 AndroidX.Compose.Material3.TextFieldLabelPosition
 AndroidX.Compose.Material3.TextFieldLabelPosition.Above
 AndroidX.Compose.Material3.TextFieldLabelPosition.Above.Above() -> void
+AndroidX.Compose.Material3.TextFieldLabelPosition.Above.Above(AndroidX.Compose.UI.IAlignmentHorizontal! alignment) -> void
+AndroidX.Compose.Material3.TextFieldLabelPosition.Above.Alignment.get -> AndroidX.Compose.UI.IAlignmentHorizontal!
 AndroidX.Compose.Material3.TextFieldLabelPosition.Attached
 AndroidX.Compose.Material3.TextFieldLabelPosition.Attached.AlwaysMinimize.get -> bool
 AndroidX.Compose.Material3.TextFieldLabelPosition.Attached.Attached() -> void
+AndroidX.Compose.Material3.TextFieldLabelPosition.Attached.Attached(bool alwaysMinimize, AndroidX.Compose.UI.IAlignmentHorizontal! minimizedAlignment, AndroidX.Compose.UI.IAlignmentHorizontal! expandedAlignment) -> void
+AndroidX.Compose.Material3.TextFieldLabelPosition.Attached.ExpandedAlignment.get -> AndroidX.Compose.UI.IAlignmentHorizontal!
+AndroidX.Compose.Material3.TextFieldLabelPosition.Attached.MinimizedAlignment.get -> AndroidX.Compose.UI.IAlignmentHorizontal!
 AndroidX.Compose.Material3.TextFieldLabelPosition.TextFieldLabelPosition(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
 AndroidX.Compose.Material3.TextKt
 AndroidX.Compose.Material3.TimeFormat_androidKt
@@ -948,8 +1154,11 @@ AndroidX.Compose.Material3.TimePickerDefaults.Colors(AndroidX.Compose.Runtime.IC
 AndroidX.Compose.Material3.TimePickerDefaults.Colors(long clockDialColor, long clockDialSelectedContentColor, long clockDialUnselectedContentColor, long selectorColor, long containerColor, long periodSelectorBorderColor, long periodSelectorSelectedContainerColor, long periodSelectorUnselectedContainerColor, long periodSelectorSelectedContentColor, long periodSelectorUnselectedContentColor, long timeSelectorSelectedContainerColor, long timeSelectorUnselectedContainerColor, long timeSelectorSelectedContentColor, long timeSelectorUnselectedContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p15, int _changed, int _changed1) -> AndroidX.Compose.Material3.TimePickerColors!
 AndroidX.Compose.Material3.TimePickerDefaults.LayoutType(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> int
 AndroidX.Compose.Material3.TimePickerDialogDefaults
+AndroidX.Compose.Material3.TimePickerDialogDefaults.DisplayModeToggle(Kotlin.Jvm.Functions.IFunction0! onDisplayModeChange, int p1, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Runtime.IComposer? _composer, int displayMode, int _changed) -> void
 AndroidX.Compose.Material3.TimePickerDialogDefaults.GetContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.TimePickerDialogDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.TimePickerDialogDefaults.MinHeightForTimePicker.get -> float
+AndroidX.Compose.Material3.TimePickerDialogDefaults.Title(int p0, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Runtime.IComposer? _composer, int displayMode, int _changed) -> void
 AndroidX.Compose.Material3.TimePickerDialogKt
 AndroidX.Compose.Material3.TimePickerDisplayMode
 AndroidX.Compose.Material3.TimePickerDisplayMode.Companion
@@ -977,10 +1186,18 @@ AndroidX.Compose.Material3.TooltipAnchorPosition.Companion.Left_lOKsHw4.get -> i
 AndroidX.Compose.Material3.TooltipAnchorPosition.Companion.Right_lOKsHw4.get -> int
 AndroidX.Compose.Material3.TooltipAnchorPosition.Companion.Start_lOKsHw4.get -> int
 AndroidX.Compose.Material3.TooltipDefaults
+AndroidX.Compose.Material3.TooltipDefaults.CaretShape() -> AndroidX.Compose.Material3.DefaultTooltipCaretShape!
+AndroidX.Compose.Material3.TooltipDefaults.CaretShape(long caretSize) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.TooltipDefaults.CaretSize.get -> long
 AndroidX.Compose.Material3.TooltipDefaults.GetPlainTooltipContainerColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.TooltipDefaults.GetPlainTooltipContainerShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.TooltipDefaults.GetPlainTooltipContentColor(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
+AndroidX.Compose.Material3.TooltipDefaults.GetRichTooltipContainerShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 AndroidX.Compose.Material3.TooltipDefaults.PlainTooltipMaxWidth.get -> float
+AndroidX.Compose.Material3.TooltipDefaults.RememberPlainTooltipPositionProvider(float spacingBetweenTooltipAndAnchor, AndroidX.Compose.Runtime.IComposer? _composer, int p2, int _changed) -> AndroidX.Compose.UI.Window.IPopupPositionProvider!
+AndroidX.Compose.Material3.TooltipDefaults.RememberRichTooltipPositionProvider(float spacingBetweenTooltipAndAnchor, AndroidX.Compose.Runtime.IComposer? _composer, int p2, int _changed) -> AndroidX.Compose.UI.Window.IPopupPositionProvider!
+AndroidX.Compose.Material3.TooltipDefaults.RememberTooltipPositionProvider(float spacingBetweenTooltipAndAnchor, AndroidX.Compose.Runtime.IComposer? _composer, int p2, int _changed) -> AndroidX.Compose.UI.Window.IPopupPositionProvider!
+AndroidX.Compose.Material3.TooltipDefaults.RememberTooltipPositionProvider(int p0, float spacingBetweenTooltipAndAnchor, AndroidX.Compose.Runtime.IComposer? _composer, int positioning, int _changed) -> AndroidX.Compose.UI.Window.IPopupPositionProvider!
 AndroidX.Compose.Material3.TooltipDefaults.RichTooltipColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.RichTooltipColors!
 AndroidX.Compose.Material3.TooltipDefaults.RichTooltipColors(long containerColor, long contentColor, long titleContentColor, long actionContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.RichTooltipColors!
 AndroidX.Compose.Material3.TooltipDefaults.RichTooltipMaxWidth.get -> float
@@ -997,6 +1214,9 @@ AndroidX.Compose.Material3.TopAppBarColors.TitleContentColor.get -> long
 AndroidX.Compose.Material3.TopAppBarDefaults
 AndroidX.Compose.Material3.TopAppBarDefaults.CenterAlignedTopAppBarColors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.TopAppBarColors!
 AndroidX.Compose.Material3.TopAppBarDefaults.CenterAlignedTopAppBarColors(long containerColor, long scrolledContainerColor, long navigationIconContentColor, long titleContentColor, long actionIconContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> AndroidX.Compose.Material3.TopAppBarColors!
+AndroidX.Compose.Material3.TopAppBarDefaults.EnterAlwaysScrollBehavior(AndroidX.Compose.Material3.TopAppBarState? state, Kotlin.Jvm.Functions.IFunction0? canScroll, AndroidX.Compose.Animation.Core.IAnimationSpec? snapAnimationSpec, AndroidX.Compose.Animation.Core.IDecayAnimationSpec? flingAnimationSpec, bool reverseLayout, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> AndroidX.Compose.Material3.ITopAppBarScrollBehavior!
+AndroidX.Compose.Material3.TopAppBarDefaults.ExitUntilCollapsedScrollBehavior(AndroidX.Compose.Material3.TopAppBarState? state, Kotlin.Jvm.Functions.IFunction0? canScroll, AndroidX.Compose.Animation.Core.IAnimationSpec? snapAnimationSpec, AndroidX.Compose.Animation.Core.IDecayAnimationSpec? flingAnimationSpec, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> AndroidX.Compose.Material3.ITopAppBarScrollBehavior!
+AndroidX.Compose.Material3.TopAppBarDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.TopAppBarDefaults.LargeAppBarCollapsedHeight.get -> float
 AndroidX.Compose.Material3.TopAppBarDefaults.LargeAppBarExpandedHeight.get -> float
 AndroidX.Compose.Material3.TopAppBarDefaults.LargeFlexibleAppBarWithSubtitleExpandedHeight.get -> float
@@ -1025,13 +1245,31 @@ AndroidX.Compose.Material3.TopAppBarState.HeightOffsetLimit.set -> void
 AndroidX.Compose.Material3.TopAppBarState.OverlappedFraction.get -> float
 AndroidX.Compose.Material3.TopAppBarState.TopAppBarState(float initialHeightOffsetLimit, float initialHeightOffset, float initialContentOffset) -> void
 AndroidX.Compose.Material3.Typography
+AndroidX.Compose.Material3.Typography.BodyLarge.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.BodyMedium.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.BodySmall.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.Copy(AndroidX.Compose.UI.Text.TextStyle! displayLarge, AndroidX.Compose.UI.Text.TextStyle! displayMedium, AndroidX.Compose.UI.Text.TextStyle! displaySmall, AndroidX.Compose.UI.Text.TextStyle! headlineLarge, AndroidX.Compose.UI.Text.TextStyle! headlineMedium, AndroidX.Compose.UI.Text.TextStyle! headlineSmall, AndroidX.Compose.UI.Text.TextStyle! titleLarge, AndroidX.Compose.UI.Text.TextStyle! titleMedium, AndroidX.Compose.UI.Text.TextStyle! titleSmall, AndroidX.Compose.UI.Text.TextStyle! bodyLarge, AndroidX.Compose.UI.Text.TextStyle! bodyMedium, AndroidX.Compose.UI.Text.TextStyle! bodySmall, AndroidX.Compose.UI.Text.TextStyle! labelLarge, AndroidX.Compose.UI.Text.TextStyle! labelMedium, AndroidX.Compose.UI.Text.TextStyle! labelSmall) -> AndroidX.Compose.Material3.Typography!
+AndroidX.Compose.Material3.Typography.DisplayLarge.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.DisplayMedium.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.DisplaySmall.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.HeadlineLarge.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.HeadlineMedium.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.HeadlineSmall.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.LabelLarge.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.LabelMedium.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.LabelSmall.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.TitleLarge.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.TitleMedium.get -> AndroidX.Compose.UI.Text.TextStyle!
+AndroidX.Compose.Material3.Typography.TitleSmall.get -> AndroidX.Compose.UI.Text.TextStyle!
 AndroidX.Compose.Material3.Typography.Typography() -> void
+AndroidX.Compose.Material3.Typography.Typography(AndroidX.Compose.UI.Text.TextStyle! displayLarge, AndroidX.Compose.UI.Text.TextStyle! displayMedium, AndroidX.Compose.UI.Text.TextStyle! displaySmall, AndroidX.Compose.UI.Text.TextStyle! headlineLarge, AndroidX.Compose.UI.Text.TextStyle! headlineMedium, AndroidX.Compose.UI.Text.TextStyle! headlineSmall, AndroidX.Compose.UI.Text.TextStyle! titleLarge, AndroidX.Compose.UI.Text.TextStyle! titleMedium, AndroidX.Compose.UI.Text.TextStyle! titleSmall, AndroidX.Compose.UI.Text.TextStyle! bodyLarge, AndroidX.Compose.UI.Text.TextStyle! bodyMedium, AndroidX.Compose.UI.Text.TextStyle! bodySmall, AndroidX.Compose.UI.Text.TextStyle! labelLarge, AndroidX.Compose.UI.Text.TextStyle! labelMedium, AndroidX.Compose.UI.Text.TextStyle! labelSmall) -> void
 AndroidX.Compose.Material3.TypographyKt
 AndroidX.Compose.Material3.TypographyKt.WhenMappings
 AndroidX.Compose.Material3.VerticalDragHandleDefaults
 AndroidX.Compose.Material3.VerticalDragHandleDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.DragHandleColors!
 AndroidX.Compose.Material3.VerticalDragHandleDefaults.Colors(long color, long pressedColor, long draggedColor, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.DragHandleColors!
 AndroidX.Compose.Material3.VerticalDragHandleDefaults.Shapes(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.DragHandleShapes!
+AndroidX.Compose.Material3.VerticalDragHandleDefaults.Shapes(AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.UI.Graphics.IShape? pressedShape, AndroidX.Compose.UI.Graphics.IShape? draggedShape, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.DragHandleShapes!
 AndroidX.Compose.Material3.VerticalDragHandleDefaults.Sizes() -> AndroidX.Compose.Material3.DragHandleSizes!
 AndroidX.Compose.Material3.VerticalDragHandleDefaults.Sizes(long size, long pressedSize, long draggedSize) -> AndroidX.Compose.Material3.DragHandleSizes!
 AndroidX.Compose.Material3.WideNavigationRailColors
@@ -1042,8 +1280,13 @@ AndroidX.Compose.Material3.WideNavigationRailColors.ModalContainerColor.get -> l
 AndroidX.Compose.Material3.WideNavigationRailColors.ModalContentColor.get -> long
 AndroidX.Compose.Material3.WideNavigationRailColors.ModalScrimColor.get -> long
 AndroidX.Compose.Material3.WideNavigationRailDefaults
+AndroidX.Compose.Material3.WideNavigationRailDefaults.Arrangement.get -> AndroidX.Compose.Foundation.Layout.Arrangement.IVertical!
 AndroidX.Compose.Material3.WideNavigationRailDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.WideNavigationRailColors!
 AndroidX.Compose.Material3.WideNavigationRailDefaults.Colors(long containerColor, long contentColor, long modalContainerColor, long modalScrimColor, long modalContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> AndroidX.Compose.Material3.WideNavigationRailColors!
+AndroidX.Compose.Material3.WideNavigationRailDefaults.GetModalCollapsedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.WideNavigationRailDefaults.GetModalExpandedShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.WideNavigationRailDefaults.GetShape(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
+AndroidX.Compose.Material3.WideNavigationRailDefaults.GetWindowInsets(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 AndroidX.Compose.Material3.WideNavigationRailDefaults.ModalExpandedProperties.get -> AndroidX.Compose.Material3.ModalWideNavigationRailProperties!
 AndroidX.Compose.Material3.WideNavigationRailItemDefaults
 AndroidX.Compose.Material3.WideNavigationRailItemDefaults.Colors(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.NavigationItemColors!
@@ -1053,6 +1296,8 @@ AndroidX.Compose.Material3.WideNavigationRailKt
 AndroidX.Compose.Material3.WideNavigationRailStateKt
 AndroidX.Compose.Material3.WideNavigationRailValue
 AndroidX.Compose.Material3.WideNavigationRail_androidKt
+abstract AndroidX.Compose.Material3.ExposedDropdownMenuBoxScope.ExposedDropdownSize(AndroidX.Compose.UI.IModifier! p0, bool matchAnchorWidth) -> AndroidX.Compose.UI.IModifier!
+abstract AndroidX.Compose.Material3.ExposedDropdownMenuBoxScope.MenuAnchor(AndroidX.Compose.UI.IModifier! p0, string! p1, bool enabled) -> AndroidX.Compose.UI.IModifier!
 const AndroidX.Compose.Material3.DatePickerDefaults.YearAbbrMonthDaySkeleton = "yMMMd" -> string!
 const AndroidX.Compose.Material3.DatePickerDefaults.YearMonthSkeleton = "yMMMM" -> string!
 const AndroidX.Compose.Material3.DatePickerDefaults.YearMonthWeekdayDaySkeleton = "yMMMMEEEEd" -> string!
@@ -1086,6 +1331,8 @@ override AndroidX.Compose.Material3.CardElevation.JniPeerMembers.get -> Java.Int
 override AndroidX.Compose.Material3.CardKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.Carousel.CarouselDefaults.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.Carousel.CarouselKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override AndroidX.Compose.Material3.Carousel.CarouselState.Companion.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override AndroidX.Compose.Material3.Carousel.CarouselState.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.Carousel.CarouselStateKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.Carousel.KeylineListKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.Carousel.KeylineSnapPositionKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
@@ -1113,6 +1360,7 @@ override AndroidX.Compose.Material3.DatePicker_jvmKt.JniPeerMembers.get -> Java.
 override AndroidX.Compose.Material3.DateRangeInputKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.DateRangePickerDefaults.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.DateRangePickerKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override AndroidX.Compose.Material3.DefaultTooltipCaretShape.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.DisplayMode.Companion.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.DisplayMode.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.DividerDefaults.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
@@ -1258,6 +1506,8 @@ override AndroidX.Compose.Material3.SliderColors.JniPeerMembers.get -> Java.Inte
 override AndroidX.Compose.Material3.SliderDefaults.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.SliderKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.SliderPositions.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override AndroidX.Compose.Material3.SliderState.Companion.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
+override AndroidX.Compose.Material3.SliderState.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.SnackbarDefaults.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.SnackbarDuration.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.SnackbarHostKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
@@ -1324,31 +1574,79 @@ override AndroidX.Compose.Material3.WideNavigationRailStateKt.JniPeerMembers.get
 override AndroidX.Compose.Material3.WideNavigationRailValue.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 override AndroidX.Compose.Material3.WideNavigationRail_androidKt.JniPeerMembers.get -> Java.Interop.JniPeerMembers!
 static AndroidX.Compose.Material3.AlertDialogDefaults.Instance.get -> AndroidX.Compose.Material3.AlertDialogDefaults!
+static AndroidX.Compose.Material3.AlertDialogKt.AlertDialog(Kotlin.Jvm.Functions.IFunction0! onDismissRequest, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Window.DialogProperties? properties, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
+static AndroidX.Compose.Material3.AlertDialogKt.BasicAlertDialog(Kotlin.Jvm.Functions.IFunction0! onDismissRequest, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Window.DialogProperties? properties, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
 static AndroidX.Compose.Material3.AlertDialogKt.DialogMaxWidth.get -> float
 static AndroidX.Compose.Material3.AlertDialogKt.DialogMinWidth.get -> float
 static AndroidX.Compose.Material3.AlertDialogKt.LocalBasicAlertDialogOverride.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.AndroidAlertDialog_androidKt.AlertDialog(Kotlin.Jvm.Functions.IFunction0! onDismissRequest, Kotlin.Jvm.Functions.IFunction2! confirmButton, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? dismissButton, Kotlin.Jvm.Functions.IFunction2? icon, Kotlin.Jvm.Functions.IFunction2? title, Kotlin.Jvm.Functions.IFunction2? text, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long iconContentColor, long titleContentColor, long textContentColor, float tonalElevation, AndroidX.Compose.UI.Window.DialogProperties? properties, AndroidX.Compose.Runtime.IComposer? _composer, int p15, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.AndroidMenu_androidKt.DefaultMenuProperties.get -> AndroidX.Compose.UI.Window.PopupProperties!
+static AndroidX.Compose.Material3.AndroidMenu_androidKt.DropdownMenu(bool expanded, Kotlin.Jvm.Functions.IFunction0! onDismissRequest, AndroidX.Compose.UI.IModifier? modifier, long offset, AndroidX.Compose.Foundation.ScrollState? scrollState, AndroidX.Compose.UI.Window.PopupProperties? properties, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.BorderStroke? border, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.AndroidMenu_androidKt.DropdownMenuItem(Kotlin.Jvm.Functions.IFunction2! text, Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, bool enabled, AndroidX.Compose.Material3.MenuItemColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.AppBarColumnKt.AppBarColumn(Kotlin.Jvm.Functions.IFunction3! overflowIndicator, AndroidX.Compose.UI.IModifier? modifier, int p2, Kotlin.Jvm.Functions.IFunction1! content, AndroidX.Compose.Runtime.IComposer? _composer, int maxItemCount, int _changed) -> void
+static AndroidX.Compose.Material3.AppBarKt.BottomAppBar(AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, float tonalElevation, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Material3.IBottomAppBarScrollBehavior? scrollBehavior, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.AppBarKt.BottomAppBar(AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, float tonalElevation, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.AppBarKt.BottomAppBar(Kotlin.Jvm.Functions.IFunction3! actions, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? floatingActionButton, long containerColor, long contentColor, float tonalElevation, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Material3.IBottomAppBarScrollBehavior? scrollBehavior, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.AppBarKt.BottomAppBar(Kotlin.Jvm.Functions.IFunction3! actions, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? floatingActionButton, long containerColor, long contentColor, float tonalElevation, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
 static AndroidX.Compose.Material3.AppBarKt.BottomAppBarState(float initialHeightOffsetLimit, float initialHeightOffset, float initialContentOffset) -> AndroidX.Compose.Material3.IBottomAppBarState!
 static AndroidX.Compose.Material3.AppBarKt.BottomAppBarVerticalPadding.get -> float
+static AndroidX.Compose.Material3.AppBarKt.CenterAlignedTopAppBar(Kotlin.Jvm.Functions.IFunction2! title, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? navigationIcon, Kotlin.Jvm.Functions.IFunction3? actions, float expandedHeight, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Material3.TopAppBarColors? colors, AndroidX.Compose.Material3.ITopAppBarScrollBehavior? scrollBehavior, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.AppBarKt.LargeTopAppBar(Kotlin.Jvm.Functions.IFunction2! title, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? navigationIcon, Kotlin.Jvm.Functions.IFunction3? actions, float collapsedHeight, float expandedHeight, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Material3.TopAppBarColors? colors, AndroidX.Compose.Material3.ITopAppBarScrollBehavior? scrollBehavior, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
 static AndroidX.Compose.Material3.AppBarKt.LocalSingleRowTopAppBarOverride.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
 static AndroidX.Compose.Material3.AppBarKt.LocalTwoRowsTopAppBarOverride.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.AppBarKt.MediumTopAppBar(Kotlin.Jvm.Functions.IFunction2! title, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? navigationIcon, Kotlin.Jvm.Functions.IFunction3? actions, float collapsedHeight, float expandedHeight, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Material3.TopAppBarColors? colors, AndroidX.Compose.Material3.ITopAppBarScrollBehavior? scrollBehavior, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
 static AndroidX.Compose.Material3.AppBarKt.RememberBottomAppBarState(float initialHeightOffsetLimit, float initialHeightOffset, float initialContentOffset, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.IBottomAppBarState!
 static AndroidX.Compose.Material3.AppBarKt.RememberTopAppBarState(float initialHeightOffsetLimit, float initialHeightOffset, float initialContentOffset, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.TopAppBarState!
+static AndroidX.Compose.Material3.AppBarKt.TopAppBar(Kotlin.Jvm.Functions.IFunction2! title, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? navigationIcon, Kotlin.Jvm.Functions.IFunction3? actions, float expandedHeight, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Material3.TopAppBarColors? colors, AndroidX.Compose.Material3.ITopAppBarScrollBehavior? scrollBehavior, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.AppBarKt.TopTitleAlphaEasing.get -> AndroidX.Compose.Animation.Core.CubicBezierEasing!
+static AndroidX.Compose.Material3.AppBarRowKt.AppBarRow(Kotlin.Jvm.Functions.IFunction3! overflowIndicator, AndroidX.Compose.UI.IModifier? modifier, int p2, Kotlin.Jvm.Functions.IFunction1! content, AndroidX.Compose.Runtime.IComposer? _composer, int maxItemCount, int _changed) -> void
 static AndroidX.Compose.Material3.AssistChipDefaults.Instance.get -> AndroidX.Compose.Material3.AssistChipDefaults!
 static AndroidX.Compose.Material3.BadgeDefaults.Instance.get -> AndroidX.Compose.Material3.BadgeDefaults!
+static AndroidX.Compose.Material3.BadgeKt.Badge(AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, Kotlin.Jvm.Functions.IFunction3? content, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
+static AndroidX.Compose.Material3.BadgeKt.BadgeEndRuler.get -> AndroidX.Compose.UI.Layout.VerticalRuler!
 static AndroidX.Compose.Material3.BadgeKt.BadgeOffset.get -> float
+static AndroidX.Compose.Material3.BadgeKt.BadgeTopRuler.get -> AndroidX.Compose.UI.Layout.HorizontalRuler!
 static AndroidX.Compose.Material3.BadgeKt.BadgeWithContentHorizontalOffset.get -> float
 static AndroidX.Compose.Material3.BadgeKt.BadgeWithContentHorizontalPadding.get -> float
 static AndroidX.Compose.Material3.BadgeKt.BadgeWithContentVerticalOffset.get -> float
+static AndroidX.Compose.Material3.BadgeKt.BadgedBox(Kotlin.Jvm.Functions.IFunction3! badge, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
 static AndroidX.Compose.Material3.BottomAppBarDefaults.Instance.get -> AndroidX.Compose.Material3.BottomAppBarDefaults!
 static AndroidX.Compose.Material3.BottomAppBarState.Companion.get -> AndroidX.Compose.Material3.BottomAppBarStateCompanion!
 static AndroidX.Compose.Material3.BottomSheetDefaults.Instance.get -> AndroidX.Compose.Material3.BottomSheetDefaults!
+static AndroidX.Compose.Material3.BottomSheetScaffoldKt.BottomSheetScaffold(Kotlin.Jvm.Functions.IFunction3! sheetContent, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.BottomSheetScaffoldState? scaffoldState, float sheetPeekHeight, float sheetMaxWidth, AndroidX.Compose.UI.Graphics.IShape? sheetShape, long sheetContainerColor, long sheetContentColor, float sheetTonalElevation, float sheetShadowElevation, Kotlin.Jvm.Functions.IFunction2? sheetDragHandle, bool sheetSwipeEnabled, Kotlin.Jvm.Functions.IFunction2? topBar, Kotlin.Jvm.Functions.IFunction3? snackbarHost, long containerColor, long contentColor, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p18, int _changed, int _changed1) -> void
 static AndroidX.Compose.Material3.BottomSheetScaffoldKt.RememberBottomSheetScaffoldState(AndroidX.Compose.Material3.SheetState? bottomSheetState, AndroidX.Compose.Material3.SnackbarHostState? snackbarHostState, AndroidX.Compose.Runtime.IComposer? _composer, int p3, int _changed) -> AndroidX.Compose.Material3.BottomSheetScaffoldState!
 static AndroidX.Compose.Material3.BottomSheetScaffoldKt.RememberStandardBottomSheetState(AndroidX.Compose.Material3.SheetValue? initialValue, Kotlin.Jvm.Functions.IFunction1? confirmValueChange, bool skipHiddenState, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.SheetState!
 static AndroidX.Compose.Material3.ButtonDefaults.Instance.get -> AndroidX.Compose.Material3.ButtonDefaults!
+static AndroidX.Compose.Material3.ButtonKt.Button(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ButtonColors? colors, AndroidX.Compose.Material3.ButtonElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.ButtonKt.ElevatedButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ButtonColors? colors, AndroidX.Compose.Material3.ButtonElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.ButtonKt.FilledTonalButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ButtonColors? colors, AndroidX.Compose.Material3.ButtonElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.ButtonKt.OutlinedButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ButtonColors? colors, AndroidX.Compose.Material3.ButtonElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.ButtonKt.TextButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ButtonColors? colors, AndroidX.Compose.Material3.ButtonElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
 static AndroidX.Compose.Material3.CardDefaults.Instance.get -> AndroidX.Compose.Material3.CardDefaults!
+static AndroidX.Compose.Material3.CardKt.Card(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.CardColors? colors, AndroidX.Compose.Material3.CardElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
+static AndroidX.Compose.Material3.CardKt.Card(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.CardColors? colors, AndroidX.Compose.Material3.CardElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.CardKt.ElevatedCard(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.CardColors? colors, AndroidX.Compose.Material3.CardElevation? elevation, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> void
+static AndroidX.Compose.Material3.CardKt.ElevatedCard(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.CardColors? colors, AndroidX.Compose.Material3.CardElevation? elevation, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.CardKt.OutlinedCard(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.CardColors? colors, AndroidX.Compose.Material3.CardElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
+static AndroidX.Compose.Material3.CardKt.OutlinedCard(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.CardColors? colors, AndroidX.Compose.Material3.CardElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
 static AndroidX.Compose.Material3.Carousel.CarouselDefaults.Instance.get -> AndroidX.Compose.Material3.Carousel.CarouselDefaults!
+static AndroidX.Compose.Material3.Carousel.CarouselKt.HorizontalCenteredHeroCarousel(AndroidX.Compose.Material3.Carousel.CarouselState! state, AndroidX.Compose.UI.IModifier? modifier, float maxItemWidth, float itemSpacing, AndroidX.Compose.Foundation.Gestures.ITargetedFlingBehavior? flingBehavior, bool userScrollEnabled, float minSmallItemWidth, float maxSmallItemWidth, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, Kotlin.Jvm.Functions.IFunction4! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.Carousel.CarouselKt.HorizontalMultiBrowseCarousel(AndroidX.Compose.Material3.Carousel.CarouselState! state, float preferredItemWidth, AndroidX.Compose.UI.IModifier? modifier, float itemSpacing, AndroidX.Compose.Foundation.Gestures.ITargetedFlingBehavior? flingBehavior, bool userScrollEnabled, float minSmallItemWidth, float maxSmallItemWidth, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, Kotlin.Jvm.Functions.IFunction4! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.Carousel.CarouselKt.HorizontalUncontainedCarousel(AndroidX.Compose.Material3.Carousel.CarouselState! state, float itemWidth, AndroidX.Compose.UI.IModifier? modifier, float itemSpacing, AndroidX.Compose.Foundation.Gestures.ITargetedFlingBehavior? flingBehavior, bool userScrollEnabled, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, Kotlin.Jvm.Functions.IFunction4! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.Carousel.CarouselStateKt.RememberCarouselState(int p0, Kotlin.Jvm.Functions.IFunction0! itemCount, AndroidX.Compose.Runtime.IComposer? _composer, int initialItem, int _changed) -> AndroidX.Compose.Material3.Carousel.CarouselState!
 static AndroidX.Compose.Material3.CheckboxDefaults.Instance.get -> AndroidX.Compose.Material3.CheckboxDefaults!
+static AndroidX.Compose.Material3.CheckboxKt.Checkbox(bool checked, Kotlin.Jvm.Functions.IFunction1? onCheckedChange, AndroidX.Compose.UI.Graphics.Drawscope.Stroke! checkmarkStroke, AndroidX.Compose.UI.Graphics.Drawscope.Stroke! outlineStroke, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.CheckboxColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.CheckboxKt.Checkbox(bool checked, Kotlin.Jvm.Functions.IFunction1? onCheckedChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.CheckboxColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
+static AndroidX.Compose.Material3.CheckboxKt.TriStateCheckbox(AndroidX.Compose.UI.State.ToggleableState! state, Kotlin.Jvm.Functions.IFunction0? onClick, AndroidX.Compose.UI.Graphics.Drawscope.Stroke! checkmarkStroke, AndroidX.Compose.UI.Graphics.Drawscope.Stroke! outlineStroke, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.CheckboxColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.CheckboxKt.TriStateCheckbox(AndroidX.Compose.UI.State.ToggleableState! state, Kotlin.Jvm.Functions.IFunction0? onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.CheckboxColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
+static AndroidX.Compose.Material3.ChipKt.AssistChip(Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ChipColors? colors, AndroidX.Compose.Material3.ChipElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p12, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.ChipKt.ElevatedAssistChip(Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ChipColors? colors, AndroidX.Compose.Material3.ChipElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p12, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.ChipKt.ElevatedFilterChip(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SelectableChipColors? colors, AndroidX.Compose.Material3.SelectableChipElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.ChipKt.ElevatedSuggestionChip(Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? icon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ChipColors? colors, AndroidX.Compose.Material3.ChipElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.ChipKt.FilterChip(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SelectableChipColors? colors, AndroidX.Compose.Material3.SelectableChipElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
 static AndroidX.Compose.Material3.ChipKt.GetDefaultSuggestionChipColors(AndroidX.Compose.Material3.ColorScheme! obj) -> AndroidX.Compose.Material3.ChipColors!
+static AndroidX.Compose.Material3.ChipKt.InputChip(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? avatar, Kotlin.Jvm.Functions.IFunction2? trailingIcon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SelectableChipColors? colors, AndroidX.Compose.Material3.SelectableChipElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p14, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.ChipKt.SuggestionChip(Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? icon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.ChipColors? colors, AndroidX.Compose.Material3.ChipElevation? elevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
 static AndroidX.Compose.Material3.ColorSchemeKt.ContentColorFor(AndroidX.Compose.Material3.ColorScheme! obj, long backgroundColor) -> long
 static AndroidX.Compose.Material3.ColorSchemeKt.ContentColorFor(long backgroundColor, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> long
 static AndroidX.Compose.Material3.ColorSchemeKt.DarkColorScheme(long primary, long onPrimary, long primaryContainer, long onPrimaryContainer, long inversePrimary, long secondary, long onSecondary, long secondaryContainer, long onSecondaryContainer, long tertiary, long onTertiary, long tertiaryContainer, long onTertiaryContainer, long background, long onBackground, long surface, long onSurface, long surfaceVariant, long onSurfaceVariant, long surfaceTint, long inverseSurface, long inverseOnSurface, long error, long onError, long errorContainer, long onErrorContainer, long outline, long outlineVariant, long scrim, long surfaceBright, long surfaceContainer, long surfaceContainerHigh, long surfaceContainerHighest, long surfaceContainerLow, long surfaceContainerLowest, long surfaceDim, long primaryFixed, long primaryFixedDim, long onPrimaryFixed, long onPrimaryFixedVariant, long secondaryFixed, long secondaryFixedDim, long onSecondaryFixed, long onSecondaryFixedVariant, long tertiaryFixed, long tertiaryFixedDim, long onTertiaryFixed, long onTertiaryFixedVariant) -> AndroidX.Compose.Material3.ColorScheme!
@@ -1357,8 +1655,13 @@ static AndroidX.Compose.Material3.ColorSchemeKt.LightColorScheme(long primary, l
 static AndroidX.Compose.Material3.ColorSchemeKt.LocalColorScheme.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
 static AndroidX.Compose.Material3.ColorSchemeKt.LocalTonalElevationEnabled.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
 static AndroidX.Compose.Material3.ColorSchemeKt.SurfaceColorAtElevation(AndroidX.Compose.Material3.ColorScheme! obj, float elevation) -> long
+static AndroidX.Compose.Material3.ContentColorKt.LocalContentColor.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.DateInputKt.InputTextFieldPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
 static AndroidX.Compose.Material3.DatePickerDefaults.Instance.get -> AndroidX.Compose.Material3.DatePickerDefaults!
+static AndroidX.Compose.Material3.DatePickerDialog_androidKt.DatePickerDialog(Kotlin.Jvm.Functions.IFunction0! onDismissRequest, Kotlin.Jvm.Functions.IFunction2! confirmButton, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? dismissButton, AndroidX.Compose.UI.Graphics.IShape? shape, float tonalElevation, AndroidX.Compose.Material3.DatePickerColors? colors, AndroidX.Compose.UI.Window.DialogProperties? properties, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.DatePickerKt.DatePicker(AndroidX.Compose.Material3.IDatePickerState! state, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.IDatePickerFormatter? dateFormatter, AndroidX.Compose.Material3.DatePickerColors? colors, Kotlin.Jvm.Functions.IFunction2? title, Kotlin.Jvm.Functions.IFunction2? headline, bool showModeToggle, AndroidX.Compose.UI.Focus.FocusRequester? focusRequester, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
 static AndroidX.Compose.Material3.DatePickerKt.DatePickerHorizontalPadding.get -> float
+static AndroidX.Compose.Material3.DatePickerKt.DatePickerModeTogglePadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
 static AndroidX.Compose.Material3.DatePickerKt.DatePickerState(Java.Util.Locale! locale, Java.Lang.Long? initialSelectedDateMillis, Java.Lang.Long? initialDisplayedMonthMillis, Kotlin.Ranges.IntRange! yearRange, int initialDisplayMode, AndroidX.Compose.Material3.ISelectableDates! selectableDates) -> AndroidX.Compose.Material3.IDatePickerState!
 static AndroidX.Compose.Material3.DatePickerKt.MonthYearHeight.get -> float
 static AndroidX.Compose.Material3.DatePickerKt.RecommendedSizeForAccessibility.get -> float
@@ -1377,9 +1680,15 @@ static AndroidX.Compose.Material3.DatePicker_jvmKt.SetDisplayedMonth(AndroidX.Co
 static AndroidX.Compose.Material3.DatePicker_jvmKt.SetSelectedDate(AndroidX.Compose.Material3.IDatePickerState! obj, Java.Time.LocalDate? date) -> void
 static AndroidX.Compose.Material3.DatePicker_jvmKt.SetSelection(AndroidX.Compose.Material3.IDateRangePickerState! obj, Java.Time.LocalDate? startDate, Java.Time.LocalDate? endDate) -> void
 static AndroidX.Compose.Material3.DateRangePickerDefaults.Instance.get -> AndroidX.Compose.Material3.DateRangePickerDefaults!
+static AndroidX.Compose.Material3.DateRangePickerKt.CalendarMonthSubheadPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+static AndroidX.Compose.Material3.DateRangePickerKt.DateRangePicker(AndroidX.Compose.Material3.IDateRangePickerState! state, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.IDatePickerFormatter? dateFormatter, AndroidX.Compose.Material3.DatePickerColors? colors, Kotlin.Jvm.Functions.IFunction2? title, Kotlin.Jvm.Functions.IFunction2? headline, bool showModeToggle, AndroidX.Compose.UI.Focus.FocusRequester? focusRequester, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
 static AndroidX.Compose.Material3.DateRangePickerKt.DateRangePickerState(Java.Util.Locale! locale, Java.Lang.Long? initialSelectedStartDateMillis, Java.Lang.Long? initialSelectedEndDateMillis, Java.Lang.Long? initialDisplayedMonthMillis, Kotlin.Ranges.IntRange! yearRange, int initialDisplayMode, AndroidX.Compose.Material3.ISelectableDates! selectableDates) -> AndroidX.Compose.Material3.IDateRangePickerState!
 static AndroidX.Compose.Material3.DateRangePickerKt.RememberDateRangePickerState(Java.Lang.Long? initialSelectedStartDateMillis, Java.Lang.Long? initialSelectedEndDateMillis, Java.Lang.Long? initialDisplayedMonthMillis, Kotlin.Ranges.IntRange? yearRange, int p4, AndroidX.Compose.Material3.ISelectableDates? selectableDates, AndroidX.Compose.Runtime.IComposer? _composer, int initialDisplayMode, int _changed) -> AndroidX.Compose.Material3.IDateRangePickerState!
 static AndroidX.Compose.Material3.DividerDefaults.Instance.get -> AndroidX.Compose.Material3.DividerDefaults!
+static AndroidX.Compose.Material3.DividerKt.Divider(AndroidX.Compose.UI.IModifier? modifier, float thickness, long color, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
+static AndroidX.Compose.Material3.DividerKt.HorizontalDivider(AndroidX.Compose.UI.IModifier? modifier, float thickness, long color, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
+static AndroidX.Compose.Material3.DividerKt.VerticalDivider(AndroidX.Compose.UI.IModifier? modifier, float thickness, long color, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
+static AndroidX.Compose.Material3.DragHandleKt.VerticalDragHandle(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.DragHandleSizes? sizes, AndroidX.Compose.Material3.DragHandleColors? colors, AndroidX.Compose.Material3.DragHandleShapes? shapes, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> void
 static AndroidX.Compose.Material3.DrawerDefaults.Instance.get -> AndroidX.Compose.Material3.DrawerDefaults!
 static AndroidX.Compose.Material3.DrawerValue.Closed.get -> AndroidX.Compose.Material3.DrawerValue?
 static AndroidX.Compose.Material3.DrawerValue.Entries.get -> Kotlin.Enums.IEnumEntries!
@@ -1389,23 +1698,55 @@ static AndroidX.Compose.Material3.DrawerValue.Values() -> AndroidX.Compose.Mater
 static AndroidX.Compose.Material3.DynamicTonalPaletteKt.DynamicDarkColorScheme(Android.Content.Context! context) -> AndroidX.Compose.Material3.ColorScheme!
 static AndroidX.Compose.Material3.DynamicTonalPaletteKt.DynamicLightColorScheme(Android.Content.Context! context) -> AndroidX.Compose.Material3.ColorScheme!
 static AndroidX.Compose.Material3.ExposedDropdownMenuDefaults.Instance.get -> AndroidX.Compose.Material3.ExposedDropdownMenuDefaults!
+static AndroidX.Compose.Material3.ExposedDropdownMenuKt.ExposedDropdownMenuBox(bool expanded, Kotlin.Jvm.Functions.IFunction1! onExpandedChange, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
 static AndroidX.Compose.Material3.FilterChipDefaults.Instance.get -> AndroidX.Compose.Material3.FilterChipDefaults!
 static AndroidX.Compose.Material3.FloatingActionButtonDefaults.Instance.get -> AndroidX.Compose.Material3.FloatingActionButtonDefaults!
+static AndroidX.Compose.Material3.FloatingActionButtonKt.ExtendedFloatingActionButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long contentColor, AndroidX.Compose.Material3.FloatingActionButtonElevation? elevation, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.FloatingActionButtonKt.ExtendedFloatingActionButton(Kotlin.Jvm.Functions.IFunction2! text, Kotlin.Jvm.Functions.IFunction2! icon, Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool expanded, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long contentColor, AndroidX.Compose.Material3.FloatingActionButtonElevation? elevation, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.FloatingActionButtonKt.FloatingActionButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long contentColor, AndroidX.Compose.Material3.FloatingActionButtonElevation? elevation, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.FloatingActionButtonKt.LargeFloatingActionButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long contentColor, AndroidX.Compose.Material3.FloatingActionButtonElevation? elevation, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.FloatingActionButtonKt.SmallFloatingActionButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long contentColor, AndroidX.Compose.Material3.FloatingActionButtonElevation? elevation, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
 static AndroidX.Compose.Material3.IconButtonDefaults.Instance.get -> AndroidX.Compose.Material3.IconButtonDefaults!
+static AndroidX.Compose.Material3.IconButtonKt.FilledIconButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.IconButtonColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.IconButtonKt.FilledIconToggleButton(bool checked, Kotlin.Jvm.Functions.IFunction1! onCheckedChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.IconToggleButtonColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.IconButtonKt.FilledTonalIconButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.IconButtonColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.IconButtonKt.FilledTonalIconToggleButton(bool checked, Kotlin.Jvm.Functions.IFunction1! onCheckedChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.IconToggleButtonColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.IconButtonKt.IconButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.IconButtonColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.UI.Graphics.IShape? shape, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.IconButtonKt.IconToggleButton(bool checked, Kotlin.Jvm.Functions.IFunction1! onCheckedChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.IconToggleButtonColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.UI.Graphics.IShape? shape, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.IconButtonKt.OutlinedIconButton(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.IconButtonColors? colors, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.IconButtonKt.OutlinedIconToggleButton(bool checked, Kotlin.Jvm.Functions.IFunction1! onCheckedChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.IconToggleButtonColors? colors, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.IconKt.Icon(AndroidX.Compose.UI.Graphics.IImageBitmap! bitmap, string? contentDescription, AndroidX.Compose.UI.IModifier? modifier, long tint, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
+static AndroidX.Compose.Material3.IconKt.Icon(AndroidX.Compose.UI.Graphics.Painter.Painter! painter, AndroidX.Compose.UI.Graphics.IColorProducer? tint, string? contentDescription, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
+static AndroidX.Compose.Material3.IconKt.Icon(AndroidX.Compose.UI.Graphics.Painter.Painter! painter, string? contentDescription, AndroidX.Compose.UI.IModifier? modifier, long tint, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
+static AndroidX.Compose.Material3.IconKt.Icon(AndroidX.Compose.UI.Graphics.Vector.ImageVector! imageVector, string? contentDescription, AndroidX.Compose.UI.IModifier? modifier, long tint, AndroidX.Compose.Runtime.IComposer? _composer, int p5, int _changed) -> void
 static AndroidX.Compose.Material3.InputChipDefaults.Instance.get -> AndroidX.Compose.Material3.InputChipDefaults!
 static AndroidX.Compose.Material3.InteractiveComponentSizeKt.LocalMinimumInteractiveComponentEnforcement.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.InteractiveComponentSizeKt.LocalMinimumInteractiveComponentSize.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.InteractiveComponentSizeKt.MinimumInteractiveComponentSize(AndroidX.Compose.UI.IModifier! obj) -> AndroidX.Compose.UI.IModifier!
+static AndroidX.Compose.Material3.InteractiveComponentSizeKt.MinimumInteractiveLeftAlignmentLine.get -> AndroidX.Compose.UI.Layout.VerticalAlignmentLine!
+static AndroidX.Compose.Material3.InteractiveComponentSizeKt.MinimumInteractiveTopAlignmentLine.get -> AndroidX.Compose.UI.Layout.HorizontalAlignmentLine!
 static AndroidX.Compose.Material3.Internal.AccessibilityUtilKt.HorizontalSemanticsBoundsPadding.get -> float
+static AndroidX.Compose.Material3.Internal.AccessibilityUtilKt.IncreaseHorizontalSemanticsBounds.get -> AndroidX.Compose.UI.IModifier!
+static AndroidX.Compose.Material3.Internal.AccessibilityUtilKt.IncreaseVerticalSemanticsBounds.get -> AndroidX.Compose.UI.IModifier!
 static AndroidX.Compose.Material3.Internal.AccessibilityUtilKt.VerticalSemanticsBoundsPadding.get -> float
+static AndroidX.Compose.Material3.Internal.LayoutUtilKt.GetHeightOrZero(AndroidX.Compose.UI.Layout.Placeable? obj) -> int
+static AndroidX.Compose.Material3.Internal.LayoutUtilKt.GetLayoutId(AndroidX.Compose.UI.Layout.IIntrinsicMeasurable! obj) -> Java.Lang.Object?
+static AndroidX.Compose.Material3.Internal.LayoutUtilKt.GetWidthOrZero(AndroidX.Compose.UI.Layout.Placeable? obj) -> int
+static AndroidX.Compose.Material3.Internal.SystemBarsDefaultInsets_androidKt.GetSystemBarsForVisualComponents(AndroidX.Compose.Foundation.Layout.WindowInsetsCompanion! obj, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Foundation.Layout.IWindowInsets!
 static AndroidX.Compose.Material3.Internal.TextFieldImplKt.AboveLabelBottomPadding.get -> float
 static AndroidX.Compose.Material3.Internal.TextFieldImplKt.AboveLabelHorizontalPadding.get -> float
+static AndroidX.Compose.Material3.Internal.TextFieldImplKt.GetExpandedAlignment(AndroidX.Compose.Material3.TextFieldLabelPosition! obj) -> AndroidX.Compose.UI.IAlignmentHorizontal!
+static AndroidX.Compose.Material3.Internal.TextFieldImplKt.GetMinimizedAlignment(AndroidX.Compose.Material3.TextFieldLabelPosition! obj) -> AndroidX.Compose.UI.IAlignmentHorizontal!
 static AndroidX.Compose.Material3.Internal.TextFieldImplKt.MinFocusedLabelLineHeight.get -> float
 static AndroidX.Compose.Material3.Internal.TextFieldImplKt.MinSupportingTextLineHeight.get -> float
 static AndroidX.Compose.Material3.Internal.TextFieldImplKt.MinTextLineHeight.get -> float
 static AndroidX.Compose.Material3.Internal.TextFieldImplKt.PrefixSuffixTextPadding.get -> float
 static AndroidX.Compose.Material3.Internal.TextFieldImplKt.SupportingTopPadding.get -> float
 static AndroidX.Compose.Material3.Internal.TextFieldImplKt.TextFieldPadding.get -> float
+static AndroidX.Compose.Material3.LabelKt.Label(Kotlin.Jvm.Functions.IFunction3! label, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, bool isPersistent, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> void
 static AndroidX.Compose.Material3.ListItemDefaults.Instance.get -> AndroidX.Compose.Material3.ListItemDefaults!
 static AndroidX.Compose.Material3.ListItemKt.LeadingContentEndPadding.get -> float
+static AndroidX.Compose.Material3.ListItemKt.ListItem(Kotlin.Jvm.Functions.IFunction2! headlineContent, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? overlineContent, Kotlin.Jvm.Functions.IFunction2? supportingContent, Kotlin.Jvm.Functions.IFunction2? leadingContent, Kotlin.Jvm.Functions.IFunction2? trailingContent, AndroidX.Compose.Material3.ListItemColors? colors, float tonalElevation, float shadowElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
 static AndroidX.Compose.Material3.ListItemKt.ListItemEndPadding.get -> float
 static AndroidX.Compose.Material3.ListItemKt.ListItemStartPadding.get -> float
 static AndroidX.Compose.Material3.ListItemKt.ListItemThreeLineVerticalPadding.get -> float
@@ -1418,15 +1759,27 @@ static AndroidX.Compose.Material3.MenuDefaults.Instance.get -> AndroidX.Compose.
 static AndroidX.Compose.Material3.MenuKt.DropdownMenuVerticalPadding.get -> float
 static AndroidX.Compose.Material3.MenuKt.MenuVerticalMargin.get -> float
 static AndroidX.Compose.Material3.ModalBottomSheetDefaults.Instance.get -> AndroidX.Compose.Material3.ModalBottomSheetDefaults!
+static AndroidX.Compose.Material3.ModalBottomSheetKt.ModalBottomSheet(Kotlin.Jvm.Functions.IFunction0! onDismissRequest, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.SheetState? sheetState, float sheetMaxWidth, bool sheetGesturesEnabled, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long contentColor, float tonalElevation, long scrimColor, Kotlin.Jvm.Functions.IFunction2? dragHandle, Kotlin.Jvm.Functions.IFunction2? contentWindowInsets, AndroidX.Compose.Material3.ModalBottomSheetProperties? properties, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p15, int _changed, int _changed1) -> void
 static AndroidX.Compose.Material3.ModalBottomSheetKt.RememberModalBottomSheetState(bool skipPartiallyExpanded, Kotlin.Jvm.Functions.IFunction1? confirmValueChange, AndroidX.Compose.Runtime.IComposer? _composer, int p3, int _changed) -> AndroidX.Compose.Material3.SheetState!
 static AndroidX.Compose.Material3.NavigationBarDefaults.Instance.get -> AndroidX.Compose.Material3.NavigationBarDefaults!
 static AndroidX.Compose.Material3.NavigationBarItemDefaults.Instance.get -> AndroidX.Compose.Material3.NavigationBarItemDefaults!
 static AndroidX.Compose.Material3.NavigationBarKt.IndicatorVerticalPadding.get -> float
 static AndroidX.Compose.Material3.NavigationBarKt.LocalNavigationBarOverride.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.NavigationBarKt.NavigationBar(AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, float tonalElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
 static AndroidX.Compose.Material3.NavigationBarKt.NavigationBarIndicatorToLabelPadding.get -> float
+static AndroidX.Compose.Material3.NavigationBarKt.NavigationBarItem(AndroidX.Compose.Foundation.Layout.IRowScope! obj, bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! icon, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? label, bool alwaysShowLabel, AndroidX.Compose.Material3.NavigationBarItemColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
 static AndroidX.Compose.Material3.NavigationBarKt.NavigationBarItemHorizontalPadding.get -> float
 static AndroidX.Compose.Material3.NavigationBarKt.NavigationBarItemToIconMinimumPadding.get -> float
 static AndroidX.Compose.Material3.NavigationDrawerItemDefaults.Instance.get -> AndroidX.Compose.Material3.NavigationDrawerItemDefaults!
+static AndroidX.Compose.Material3.NavigationDrawerKt.DismissibleDrawerSheet(AndroidX.Compose.Material3.DrawerState! drawerState, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? drawerShape, long drawerContainerColor, long drawerContentColor, float drawerTonalElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationDrawerKt.DismissibleDrawerSheet(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? drawerShape, long drawerContainerColor, long drawerContentColor, float drawerTonalElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationDrawerKt.DismissibleNavigationDrawer(Kotlin.Jvm.Functions.IFunction2! drawerContent, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.DrawerState? drawerState, bool gesturesEnabled, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p6, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationDrawerKt.ModalDrawerSheet(AndroidX.Compose.Material3.DrawerState! drawerState, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? drawerShape, long drawerContainerColor, long drawerContentColor, float drawerTonalElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationDrawerKt.ModalDrawerSheet(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? drawerShape, long drawerContainerColor, long drawerContentColor, float drawerTonalElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationDrawerKt.ModalNavigationDrawer(Kotlin.Jvm.Functions.IFunction2! drawerContent, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.DrawerState? drawerState, bool gesturesEnabled, long scrimColor, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationDrawerKt.NavigationDrawerItem(Kotlin.Jvm.Functions.IFunction2! label, bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? icon, Kotlin.Jvm.Functions.IFunction2? badge, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.INavigationDrawerItemColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationDrawerKt.PermanentDrawerSheet(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? drawerShape, long drawerContainerColor, long drawerContentColor, float drawerTonalElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationDrawerKt.PermanentNavigationDrawer(Kotlin.Jvm.Functions.IFunction2! drawerContent, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
 static AndroidX.Compose.Material3.NavigationDrawerKt.PredictiveBackDrawerMaxScaleXDistanceGrow.get -> float
 static AndroidX.Compose.Material3.NavigationDrawerKt.PredictiveBackDrawerMaxScaleXDistanceShrink.get -> float
 static AndroidX.Compose.Material3.NavigationDrawerKt.PredictiveBackDrawerMaxScaleYDistance.get -> float
@@ -1434,37 +1787,79 @@ static AndroidX.Compose.Material3.NavigationDrawerKt.RememberDrawerState(Android
 static AndroidX.Compose.Material3.NavigationRailDefaults.Instance.get -> AndroidX.Compose.Material3.NavigationRailDefaults!
 static AndroidX.Compose.Material3.NavigationRailItemDefaults.Instance.get -> AndroidX.Compose.Material3.NavigationRailItemDefaults!
 static AndroidX.Compose.Material3.NavigationRailKt.LocalNavigationRailOverride.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.NavigationRailKt.NavigationRail(AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, Kotlin.Jvm.Functions.IFunction3? header, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
+static AndroidX.Compose.Material3.NavigationRailKt.NavigationRailItem(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! icon, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? label, bool alwaysShowLabel, AndroidX.Compose.Material3.NavigationRailItemColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
 static AndroidX.Compose.Material3.NavigationRailKt.NavigationRailItemHeight.get -> float
 static AndroidX.Compose.Material3.NavigationRailKt.NavigationRailItemVerticalPadding.get -> float
 static AndroidX.Compose.Material3.NavigationRailKt.NavigationRailItemWidth.get -> float
 static AndroidX.Compose.Material3.NavigationRailKt.NavigationRailVerticalPadding.get -> float
 static AndroidX.Compose.Material3.OutlinedTextFieldDefaults.Instance.get -> AndroidX.Compose.Material3.OutlinedTextFieldDefaults!
+static AndroidX.Compose.Material3.OutlinedTextFieldKt.OutlinedTextField(AndroidX.Compose.Foundation.Text.Input.TextFieldState! state, AndroidX.Compose.UI.IModifier? modifier, bool enabled, bool readOnly, AndroidX.Compose.UI.Text.TextStyle? textStyle, AndroidX.Compose.Material3.TextFieldLabelPosition? labelPosition, Kotlin.Jvm.Functions.IFunction3? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.Foundation.Text.Input.IInputTransformation? inputTransformation, AndroidX.Compose.Foundation.Text.Input.IOutputTransformation? outputTransformation, AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions, AndroidX.Compose.Foundation.Text.Input.IKeyboardActionHandler? onKeyboardAction, AndroidX.Compose.Foundation.Text.Input.ITextFieldLineLimits? lineLimits, Kotlin.Jvm.Functions.IFunction2? onTextLayout, AndroidX.Compose.Foundation.ScrollState? scrollState, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p26, int _changed, int _changed1, int _changed2) -> void
+static AndroidX.Compose.Material3.OutlinedTextFieldKt.OutlinedTextField(AndroidX.Compose.UI.Text.Input.TextFieldValue! value, Kotlin.Jvm.Functions.IFunction1! onValueChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, bool readOnly, AndroidX.Compose.UI.Text.TextStyle? textStyle, Kotlin.Jvm.Functions.IFunction2? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.UI.Text.Input.IVisualTransformation? visualTransformation, AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions, AndroidX.Compose.Foundation.Text.KeyboardActions? keyboardActions, bool singleLine, int p18, int maxLines, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Runtime.IComposer? _composer, int minLines, int _changed, int _changed1, int _changed2) -> void
+static AndroidX.Compose.Material3.OutlinedTextFieldKt.OutlinedTextField(string! value, Kotlin.Jvm.Functions.IFunction1! onValueChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, bool readOnly, AndroidX.Compose.UI.Text.TextStyle? textStyle, Kotlin.Jvm.Functions.IFunction2? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.UI.Text.Input.IVisualTransformation? visualTransformation, AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions, AndroidX.Compose.Foundation.Text.KeyboardActions? keyboardActions, bool singleLine, int p18, int maxLines, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Runtime.IComposer? _composer, int minLines, int _changed, int _changed1, int _changed2) -> void
 static AndroidX.Compose.Material3.ProgressIndicatorDefaults.Instance.get -> AndroidX.Compose.Material3.ProgressIndicatorDefaults!
+static AndroidX.Compose.Material3.ProgressIndicatorKt.CircularIndeterminateGlobalRotationAnimationSpec.get -> AndroidX.Compose.Animation.Core.InfiniteRepeatableSpec!
+static AndroidX.Compose.Material3.ProgressIndicatorKt.CircularIndeterminateProgressAnimationSpec.get -> AndroidX.Compose.Animation.Core.InfiniteRepeatableSpec!
+static AndroidX.Compose.Material3.ProgressIndicatorKt.CircularIndeterminateRotationAnimationSpec.get -> AndroidX.Compose.Animation.Core.InfiniteRepeatableSpec!
 static AndroidX.Compose.Material3.ProgressIndicatorKt.CircularIndicatorDiameter.get -> float
+static AndroidX.Compose.Material3.ProgressIndicatorKt.CircularProgressEasing.get -> AndroidX.Compose.Animation.Core.CubicBezierEasing!
+static AndroidX.Compose.Material3.ProgressIndicatorKt.CircularProgressIndicator(AndroidX.Compose.UI.IModifier? modifier, long color, float strokeWidth, long trackColor, int p4, float gapSize, AndroidX.Compose.Runtime.IComposer? _composer, int strokeCap, int _changed) -> void
+static AndroidX.Compose.Material3.ProgressIndicatorKt.CircularProgressIndicator(Kotlin.Jvm.Functions.IFunction0! progress, AndroidX.Compose.UI.IModifier? modifier, long color, float strokeWidth, long trackColor, int p5, float gapSize, AndroidX.Compose.Runtime.IComposer? _composer, int strokeCap, int _changed) -> void
+static AndroidX.Compose.Material3.ProgressIndicatorKt.CircularProgressIndicator(float progress, AndroidX.Compose.UI.IModifier? modifier, long color, float strokeWidth, long trackColor, int p5, AndroidX.Compose.Runtime.IComposer? _composer, int strokeCap, int _changed) -> void
+static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearIndeterminateFirstLineHeadAnimationSpec.get -> AndroidX.Compose.Animation.Core.InfiniteRepeatableSpec!
+static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearIndeterminateFirstLineTailAnimationSpec.get -> AndroidX.Compose.Animation.Core.InfiniteRepeatableSpec!
+static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearIndeterminateProgressEasing.get -> AndroidX.Compose.Animation.Core.CubicBezierEasing!
+static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearIndeterminateSecondLineHeadAnimationSpec.get -> AndroidX.Compose.Animation.Core.InfiniteRepeatableSpec!
+static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearIndeterminateSecondLineTailAnimationSpec.get -> AndroidX.Compose.Animation.Core.InfiniteRepeatableSpec!
 static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearIndicatorHeight.get -> float
 static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearIndicatorWidth.get -> float
+static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearProgressIndicator(AndroidX.Compose.UI.IModifier? modifier, long color, long trackColor, int p3, float gapSize, AndroidX.Compose.Runtime.IComposer? _composer, int strokeCap, int _changed) -> void
+static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearProgressIndicator(Kotlin.Jvm.Functions.IFunction0! progress, AndroidX.Compose.UI.IModifier? modifier, long color, long trackColor, int p4, float gapSize, Kotlin.Jvm.Functions.IFunction1? drawStopIndicator, AndroidX.Compose.Runtime.IComposer? _composer, int strokeCap, int _changed) -> void
+static AndroidX.Compose.Material3.ProgressIndicatorKt.LinearProgressIndicator(float progress, AndroidX.Compose.UI.IModifier? modifier, long color, long trackColor, int p4, AndroidX.Compose.Runtime.IComposer? _composer, int strokeCap, int _changed) -> void
 static AndroidX.Compose.Material3.ProgressIndicatorKt.StopIndicatorTrailingSpace.get -> float
 static AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults.Instance.get -> AndroidX.Compose.Material3.PullToRefresh.PullToRefreshDefaults!
+static AndroidX.Compose.Material3.PullToRefresh.PullToRefreshKt.PullToRefresh(AndroidX.Compose.UI.IModifier! obj, bool isRefreshing, AndroidX.Compose.Material3.PullToRefresh.IPullToRefreshState! state, bool enabled, float threshold, Kotlin.Jvm.Functions.IFunction0! onRefresh) -> AndroidX.Compose.UI.IModifier!
+static AndroidX.Compose.Material3.PullToRefresh.PullToRefreshKt.PullToRefreshBox(bool isRefreshing, Kotlin.Jvm.Functions.IFunction0! onRefresh, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.PullToRefresh.IPullToRefreshState? state, AndroidX.Compose.UI.IAlignment? contentAlignment, Kotlin.Jvm.Functions.IFunction3? indicator, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
 static AndroidX.Compose.Material3.PullToRefresh.PullToRefreshKt.PullToRefreshState() -> AndroidX.Compose.Material3.PullToRefresh.IPullToRefreshState!
 static AndroidX.Compose.Material3.PullToRefresh.PullToRefreshKt.RememberPullToRefreshState(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.Material3.PullToRefresh.IPullToRefreshState!
 static AndroidX.Compose.Material3.PullToRefresh.PullToRefreshKt.SpinnerContainerSize.get -> float
 static AndroidX.Compose.Material3.PullToRefresh.PullToRefreshKt.SpinnerSize.get -> float
 static AndroidX.Compose.Material3.RadioButtonDefaults.Instance.get -> AndroidX.Compose.Material3.RadioButtonDefaults!
+static AndroidX.Compose.Material3.RadioButtonKt.RadioButton(bool selected, Kotlin.Jvm.Functions.IFunction0? onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.RadioButtonColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p7, int _changed) -> void
 static AndroidX.Compose.Material3.RippleDefaults.Instance.get -> AndroidX.Compose.Material3.RippleDefaults!
 static AndroidX.Compose.Material3.RippleKt.LocalRippleConfiguration.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.RippleKt.Ripple(AndroidX.Compose.UI.Graphics.IColorProducer! color, bool bounded, float radius) -> AndroidX.Compose.Foundation.IIndicationNodeFactory!
+static AndroidX.Compose.Material3.RippleKt.Ripple(bool bounded, float radius, long color) -> AndroidX.Compose.Foundation.IIndicationNodeFactory!
 static AndroidX.Compose.Material3.ScaffoldDefaults.Instance.get -> AndroidX.Compose.Material3.ScaffoldDefaults!
+static AndroidX.Compose.Material3.ScaffoldKt.Scaffold(AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? topBar, Kotlin.Jvm.Functions.IFunction2? bottomBar, Kotlin.Jvm.Functions.IFunction2? snackbarHost, Kotlin.Jvm.Functions.IFunction2? floatingActionButton, int p5, long containerColor, long contentColor, AndroidX.Compose.Foundation.Layout.IWindowInsets? contentWindowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int floatingActionButtonPosition, int _changed) -> void
 static AndroidX.Compose.Material3.SearchBarDefaults.Instance.get -> AndroidX.Compose.Material3.SearchBarDefaults!
 static AndroidX.Compose.Material3.SearchBarKt.DockedExpandedTableMinHeight.get -> float
+static AndroidX.Compose.Material3.SearchBarKt.DockedSearchBar(Kotlin.Jvm.Functions.IFunction2! inputField, bool expanded, Kotlin.Jvm.Functions.IFunction1! onExpandedChange, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SearchBarColors? colors, float tonalElevation, float shadowElevation, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.SearchBarKt.DockedSearchBar(string! query, Kotlin.Jvm.Functions.IFunction1! onQueryChange, Kotlin.Jvm.Functions.IFunction1! onSearch, bool active, Kotlin.Jvm.Functions.IFunction1! onActiveChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SearchBarColors? colors, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p17, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.SearchBarKt.ExpandedDockedSearchBar(AndroidX.Compose.Material3.SearchBarState! state, Kotlin.Jvm.Functions.IFunction2! inputField, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SearchBarColors? colors, float tonalElevation, float shadowElevation, AndroidX.Compose.UI.Window.PopupProperties? properties, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.SearchBarKt.ExpandedFullScreenSearchBar(AndroidX.Compose.Material3.SearchBarState! state, Kotlin.Jvm.Functions.IFunction2! inputField, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? collapsedShape, AndroidX.Compose.Material3.SearchBarColors? colors, float tonalElevation, float shadowElevation, Kotlin.Jvm.Functions.IFunction2? windowInsets, AndroidX.Compose.UI.Window.DialogProperties? properties, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.SearchBarKt.RememberSearchBarState(AndroidX.Compose.Material3.SearchBarValue? initialValue, AndroidX.Compose.Animation.Core.IAnimationSpec? animationSpecForExpand, AndroidX.Compose.Animation.Core.IAnimationSpec? animationSpecForCollapse, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.SearchBarState!
+static AndroidX.Compose.Material3.SearchBarKt.SearchBar(AndroidX.Compose.Material3.SearchBarState! state, Kotlin.Jvm.Functions.IFunction2! inputField, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SearchBarColors? colors, float tonalElevation, float shadowElevation, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.SearchBarKt.SearchBar(Kotlin.Jvm.Functions.IFunction2! inputField, bool expanded, Kotlin.Jvm.Functions.IFunction1! onExpandedChange, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SearchBarColors? colors, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.SearchBarKt.SearchBar(string! query, Kotlin.Jvm.Functions.IFunction1! onQueryChange, Kotlin.Jvm.Functions.IFunction1! onSearch, bool active, Kotlin.Jvm.Functions.IFunction1! onActiveChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SearchBarColors? colors, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p18, int _changed, int _changed1) -> void
 static AndroidX.Compose.Material3.SearchBarKt.SearchBarAsTopBarPadding.get -> float
 static AndroidX.Compose.Material3.SearchBarKt.SearchBarMinWidth.get -> float
 static AndroidX.Compose.Material3.SearchBarKt.SearchBarVerticalPadding.get -> float
+static AndroidX.Compose.Material3.SearchBarKt.TopSearchBar(AndroidX.Compose.Material3.SearchBarState! state, Kotlin.Jvm.Functions.IFunction2! inputField, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.SearchBarColors? colors, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Material3.ISearchBarScrollBehavior? scrollBehavior, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
 static AndroidX.Compose.Material3.SearchBarValue.Collapsed.get -> AndroidX.Compose.Material3.SearchBarValue?
 static AndroidX.Compose.Material3.SearchBarValue.Entries.get -> Kotlin.Enums.IEnumEntries!
 static AndroidX.Compose.Material3.SearchBarValue.Expanded.get -> AndroidX.Compose.Material3.SearchBarValue?
 static AndroidX.Compose.Material3.SearchBarValue.ValueOf(string? value) -> AndroidX.Compose.Material3.SearchBarValue?
 static AndroidX.Compose.Material3.SearchBarValue.Values() -> AndroidX.Compose.Material3.SearchBarValue![]?
+static AndroidX.Compose.Material3.SecureTextFieldKt.OutlinedSecureTextField(AndroidX.Compose.Foundation.Text.Input.TextFieldState! state, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Text.TextStyle? textStyle, AndroidX.Compose.Material3.TextFieldLabelPosition? labelPosition, Kotlin.Jvm.Functions.IFunction3? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.Foundation.Text.Input.IInputTransformation? inputTransformation, int p14, char textObfuscationCharacter, AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions, AndroidX.Compose.Foundation.Text.Input.IKeyboardActionHandler? onKeyboardAction, Kotlin.Jvm.Functions.IFunction2? onTextLayout, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int textObfuscationMode, int _changed, int _changed1, int _changed2) -> void
+static AndroidX.Compose.Material3.SecureTextFieldKt.SecureTextField(AndroidX.Compose.Foundation.Text.Input.TextFieldState! state, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Text.TextStyle? textStyle, AndroidX.Compose.Material3.TextFieldLabelPosition? labelPosition, Kotlin.Jvm.Functions.IFunction3? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.Foundation.Text.Input.IInputTransformation? inputTransformation, int p14, char textObfuscationCharacter, AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions, AndroidX.Compose.Foundation.Text.Input.IKeyboardActionHandler? onKeyboardAction, Kotlin.Jvm.Functions.IFunction2? onTextLayout, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int textObfuscationMode, int _changed, int _changed1, int _changed2) -> void
 static AndroidX.Compose.Material3.SegmentedButtonDefaults.Instance.get -> AndroidX.Compose.Material3.SegmentedButtonDefaults!
+static AndroidX.Compose.Material3.SegmentedButtonKt.MultiChoiceSegmentedButtonRow(AndroidX.Compose.UI.IModifier? modifier, float space, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
+static AndroidX.Compose.Material3.SegmentedButtonKt.SegmentedButton(AndroidX.Compose.Material3.IMultiChoiceSegmentedButtonRowScope! obj, bool checked, Kotlin.Jvm.Functions.IFunction1! onCheckedChange, AndroidX.Compose.UI.Graphics.IShape! shape, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.SegmentedButtonColors? colors, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2? icon, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.SegmentedButtonKt.SegmentedButton(AndroidX.Compose.Material3.ISingleChoiceSegmentedButtonRowScope! obj, bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.Graphics.IShape! shape, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.SegmentedButtonColors? colors, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2? icon, Kotlin.Jvm.Functions.IFunction2! label, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.SegmentedButtonKt.SingleChoiceSegmentedButtonRow(AndroidX.Compose.UI.IModifier? modifier, float space, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
 static AndroidX.Compose.Material3.ShapeDefaults.Instance.get -> AndroidX.Compose.Material3.ShapeDefaults!
+static AndroidX.Compose.Material3.ShapesKt.GetValue(Java.Lang.Enum! obj, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Graphics.IShape!
 static AndroidX.Compose.Material3.ShapesKt.LocalShapes.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
 static AndroidX.Compose.Material3.SheetValue.Entries.get -> Kotlin.Enums.IEnumEntries!
 static AndroidX.Compose.Material3.SheetValue.Expanded.get -> AndroidX.Compose.Material3.SheetValue?
@@ -1475,6 +1870,8 @@ static AndroidX.Compose.Material3.SheetValue.Values() -> AndroidX.Compose.Materi
 static AndroidX.Compose.Material3.ShortNavigationBarDefaults.Instance.get -> AndroidX.Compose.Material3.ShortNavigationBarDefaults!
 static AndroidX.Compose.Material3.ShortNavigationBarItemDefaults.Instance.get -> AndroidX.Compose.Material3.ShortNavigationBarItemDefaults!
 static AndroidX.Compose.Material3.ShortNavigationBarKt.LocalShortNavigationBarOverride.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.ShortNavigationBarKt.ShortNavigationBar(AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, int p4, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int arrangement, int _changed) -> void
+static AndroidX.Compose.Material3.ShortNavigationBarKt.ShortNavigationBarItem(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! icon, Kotlin.Jvm.Functions.IFunction2? label, AndroidX.Compose.UI.IModifier? modifier, bool enabled, int p6, AndroidX.Compose.Material3.NavigationItemColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int iconPosition, int _changed) -> void
 static AndroidX.Compose.Material3.ShortNavigationBarKt.StartIconIndicatorHorizontalPadding.get -> float
 static AndroidX.Compose.Material3.ShortNavigationBarKt.StartIconIndicatorVerticalPadding.get -> float
 static AndroidX.Compose.Material3.ShortNavigationBarKt.StartIconToLabelPadding.get -> float
@@ -1483,8 +1880,16 @@ static AndroidX.Compose.Material3.ShortNavigationBarKt.TopIconIndicatorToLabelPa
 static AndroidX.Compose.Material3.ShortNavigationBarKt.TopIconIndicatorVerticalPadding.get -> float
 static AndroidX.Compose.Material3.ShortNavigationBarKt.TopIconItemVerticalPadding.get -> float
 static AndroidX.Compose.Material3.SliderDefaults.Instance.get -> AndroidX.Compose.Material3.SliderDefaults!
+static AndroidX.Compose.Material3.SliderKt.CornerSizeAlignmentLine.get -> AndroidX.Compose.UI.Layout.VerticalAlignmentLine!
 static AndroidX.Compose.Material3.SliderKt.IsSpecified(long obj) -> bool
+static AndroidX.Compose.Material3.SliderKt.RangeSlider(AndroidX.Compose.Material3.RangeSliderState! state, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.SliderColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? startInteractionSource, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? endInteractionSource, Kotlin.Jvm.Functions.IFunction3? startThumb, Kotlin.Jvm.Functions.IFunction3? endThumb, Kotlin.Jvm.Functions.IFunction3? track, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.SliderKt.RangeSlider(Kotlin.Ranges.IClosedFloatingPointRange! value, Kotlin.Jvm.Functions.IFunction1! onValueChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Ranges.IClosedFloatingPointRange? valueRange, Kotlin.Jvm.Functions.IFunction0? onValueChangeFinished, AndroidX.Compose.Material3.SliderColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? startInteractionSource, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? endInteractionSource, Kotlin.Jvm.Functions.IFunction3? startThumb, Kotlin.Jvm.Functions.IFunction3? endThumb, Kotlin.Jvm.Functions.IFunction3? track, int p12, AndroidX.Compose.Runtime.IComposer? _composer, int steps, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.SliderKt.RangeSlider(Kotlin.Ranges.IClosedFloatingPointRange! value, Kotlin.Jvm.Functions.IFunction1! onValueChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Ranges.IClosedFloatingPointRange? valueRange, int p5, Kotlin.Jvm.Functions.IFunction0? onValueChangeFinished, AndroidX.Compose.Material3.SliderColors? colors, AndroidX.Compose.Runtime.IComposer? _composer, int steps, int _changed) -> void
 static AndroidX.Compose.Material3.SliderKt.RememberRangeSliderState(float activeRangeStart, float activeRangeEnd, int p2, Kotlin.Jvm.Functions.IFunction0? onValueChangeFinished, Kotlin.Ranges.IClosedFloatingPointRange? valueRange, AndroidX.Compose.Runtime.IComposer? _composer, int steps, int _changed) -> AndroidX.Compose.Material3.RangeSliderState!
+static AndroidX.Compose.Material3.SliderKt.RememberSliderState(float value, int p1, Kotlin.Jvm.Functions.IFunction0? onValueChangeFinished, Kotlin.Ranges.IClosedFloatingPointRange? valueRange, AndroidX.Compose.Runtime.IComposer? _composer, int steps, int _changed) -> AndroidX.Compose.Material3.SliderState!
+static AndroidX.Compose.Material3.SliderKt.Slider(AndroidX.Compose.Material3.SliderState! state, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.Material3.SliderColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3? thumb, Kotlin.Jvm.Functions.IFunction3? track, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
+static AndroidX.Compose.Material3.SliderKt.Slider(float value, Kotlin.Jvm.Functions.IFunction1! onValueChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction0? onValueChangeFinished, AndroidX.Compose.Material3.SliderColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, int p7, Kotlin.Jvm.Functions.IFunction3? thumb, Kotlin.Jvm.Functions.IFunction3? track, Kotlin.Ranges.IClosedFloatingPointRange? valueRange, AndroidX.Compose.Runtime.IComposer? _composer, int steps, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.SliderKt.Slider(float value, Kotlin.Jvm.Functions.IFunction1! onValueChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Ranges.IClosedFloatingPointRange? valueRange, int p5, Kotlin.Jvm.Functions.IFunction0? onValueChangeFinished, AndroidX.Compose.Material3.SliderColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int steps, int _changed) -> void
 static AndroidX.Compose.Material3.SliderKt.ThumbWidth.get -> float
 static AndroidX.Compose.Material3.SliderKt.TrackHeight.get -> float
 static AndroidX.Compose.Material3.SnackbarDefaults.Instance.get -> AndroidX.Compose.Material3.SnackbarDefaults!
@@ -1494,15 +1899,24 @@ static AndroidX.Compose.Material3.SnackbarDuration.Long.get -> AndroidX.Compose.
 static AndroidX.Compose.Material3.SnackbarDuration.Short.get -> AndroidX.Compose.Material3.SnackbarDuration?
 static AndroidX.Compose.Material3.SnackbarDuration.ValueOf(string? value) -> AndroidX.Compose.Material3.SnackbarDuration?
 static AndroidX.Compose.Material3.SnackbarDuration.Values() -> AndroidX.Compose.Material3.SnackbarDuration![]?
+static AndroidX.Compose.Material3.SnackbarHostKt.SnackbarHost(AndroidX.Compose.Material3.SnackbarHostState! hostState, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction3? snackbar, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
+static AndroidX.Compose.Material3.SnackbarKt.Snackbar(AndroidX.Compose.Material3.ISnackbarData! snackbarData, AndroidX.Compose.UI.IModifier? modifier, bool actionOnNewLine, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long contentColor, long actionColor, long actionContentColor, long dismissActionContentColor, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.SnackbarKt.Snackbar(AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? action, Kotlin.Jvm.Functions.IFunction2? dismissAction, bool actionOnNewLine, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, long contentColor, long actionContentColor, long dismissActionContentColor, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
 static AndroidX.Compose.Material3.SnackbarResult.ActionPerformed.get -> AndroidX.Compose.Material3.SnackbarResult?
 static AndroidX.Compose.Material3.SnackbarResult.Dismissed.get -> AndroidX.Compose.Material3.SnackbarResult?
 static AndroidX.Compose.Material3.SnackbarResult.Entries.get -> Kotlin.Enums.IEnumEntries!
 static AndroidX.Compose.Material3.SnackbarResult.ValueOf(string? value) -> AndroidX.Compose.Material3.SnackbarResult?
 static AndroidX.Compose.Material3.SnackbarResult.Values() -> AndroidX.Compose.Material3.SnackbarResult![]?
 static AndroidX.Compose.Material3.SuggestionChipDefaults.Instance.get -> AndroidX.Compose.Material3.SuggestionChipDefaults!
+static AndroidX.Compose.Material3.SurfaceKt.LocalAbsoluteTonalElevation.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.SurfaceKt.Surface(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? shape, long color, long contentColor, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.BorderStroke? border, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.SurfaceKt.Surface(Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, long color, long contentColor, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p12, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.SurfaceKt.Surface(bool checked, Kotlin.Jvm.Functions.IFunction1! onCheckedChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, long color, long contentColor, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.SurfaceKt.Surface(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, AndroidX.Compose.UI.Graphics.IShape? shape, long color, long contentColor, float tonalElevation, float shadowElevation, AndroidX.Compose.Foundation.BorderStroke? border, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
 static AndroidX.Compose.Material3.SwipeToDismissBoxDefaults.Instance.get -> AndroidX.Compose.Material3.SwipeToDismissBoxDefaults!
 static AndroidX.Compose.Material3.SwipeToDismissBoxKt.RememberSwipeToDismissBoxState(AndroidX.Compose.Material3.SwipeToDismissBoxValue? initialValue, Kotlin.Jvm.Functions.IFunction1? confirmValueChange, Kotlin.Jvm.Functions.IFunction1? positionalThreshold, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.SwipeToDismissBoxState!
 static AndroidX.Compose.Material3.SwipeToDismissBoxKt.RememberSwipeToDismissBoxState(AndroidX.Compose.Material3.SwipeToDismissBoxValue? initialValue, Kotlin.Jvm.Functions.IFunction1? positionalThreshold, AndroidX.Compose.Runtime.IComposer? _composer, int p3, int _changed) -> AndroidX.Compose.Material3.SwipeToDismissBoxState!
+static AndroidX.Compose.Material3.SwipeToDismissBoxKt.SwipeToDismissBox(AndroidX.Compose.Material3.SwipeToDismissBoxState! state, Kotlin.Jvm.Functions.IFunction3! backgroundContent, AndroidX.Compose.UI.IModifier? modifier, bool enableDismissFromStartToEnd, bool enableDismissFromEndToStart, bool gesturesEnabled, Kotlin.Jvm.Functions.IFunction1? onDismiss, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
 static AndroidX.Compose.Material3.SwipeToDismissBoxValue.EndToStart.get -> AndroidX.Compose.Material3.SwipeToDismissBoxValue?
 static AndroidX.Compose.Material3.SwipeToDismissBoxValue.Entries.get -> Kotlin.Enums.IEnumEntries!
 static AndroidX.Compose.Material3.SwipeToDismissBoxValue.Settled.get -> AndroidX.Compose.Material3.SwipeToDismissBoxValue?
@@ -1510,39 +1924,71 @@ static AndroidX.Compose.Material3.SwipeToDismissBoxValue.StartToEnd.get -> Andro
 static AndroidX.Compose.Material3.SwipeToDismissBoxValue.ValueOf(string? value) -> AndroidX.Compose.Material3.SwipeToDismissBoxValue?
 static AndroidX.Compose.Material3.SwipeToDismissBoxValue.Values() -> AndroidX.Compose.Material3.SwipeToDismissBoxValue![]?
 static AndroidX.Compose.Material3.SwitchDefaults.Instance.get -> AndroidX.Compose.Material3.SwitchDefaults!
+static AndroidX.Compose.Material3.SwitchKt.Switch(bool checked, Kotlin.Jvm.Functions.IFunction1? onCheckedChange, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? thumbContent, bool enabled, AndroidX.Compose.Material3.SwitchColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p8, int _changed) -> void
 static AndroidX.Compose.Material3.SwitchKt.ThumbDiameter.get -> float
 static AndroidX.Compose.Material3.SwitchKt.UncheckedThumbDiameter.get -> float
 static AndroidX.Compose.Material3.TabKt.HorizontalTextPadding.get -> float
+static AndroidX.Compose.Material3.TabKt.LeadingIconTab(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! text, Kotlin.Jvm.Functions.IFunction2! icon, AndroidX.Compose.UI.IModifier? modifier, bool enabled, long selectedContentColor, long unselectedContentColor, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.TabKt.Tab(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, Kotlin.Jvm.Functions.IFunction2? text, Kotlin.Jvm.Functions.IFunction2? icon, long selectedContentColor, long unselectedContentColor, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
+static AndroidX.Compose.Material3.TabKt.Tab(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, AndroidX.Compose.UI.IModifier? modifier, bool enabled, long selectedContentColor, long unselectedContentColor, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
 static AndroidX.Compose.Material3.TabRowDefaults.Instance.get -> AndroidX.Compose.Material3.TabRowDefaults!
+static AndroidX.Compose.Material3.TabRowKt.PrimaryScrollableTabRow(int p0, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Foundation.ScrollState? scrollState, long containerColor, long contentColor, float edgePadding, Kotlin.Jvm.Functions.IFunction3? indicator, Kotlin.Jvm.Functions.IFunction2? divider, float minTabWidth, Kotlin.Jvm.Functions.IFunction2! tabs, AndroidX.Compose.Runtime.IComposer? _composer, int selectedTabIndex, int _changed) -> void
+static AndroidX.Compose.Material3.TabRowKt.PrimaryTabRow(int p0, AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, Kotlin.Jvm.Functions.IFunction3? indicator, Kotlin.Jvm.Functions.IFunction2? divider, Kotlin.Jvm.Functions.IFunction2! tabs, AndroidX.Compose.Runtime.IComposer? _composer, int selectedTabIndex, int _changed) -> void
+static AndroidX.Compose.Material3.TabRowKt.ScrollableTabRow(int p0, AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, float edgePadding, Kotlin.Jvm.Functions.IFunction3? indicator, Kotlin.Jvm.Functions.IFunction2? divider, Kotlin.Jvm.Functions.IFunction2! tabs, AndroidX.Compose.Runtime.IComposer? _composer, int selectedTabIndex, int _changed) -> void
+static AndroidX.Compose.Material3.TabRowKt.SecondaryScrollableTabRow(int p0, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Foundation.ScrollState? scrollState, long containerColor, long contentColor, float edgePadding, Kotlin.Jvm.Functions.IFunction3? indicator, Kotlin.Jvm.Functions.IFunction2? divider, float minTabWidth, Kotlin.Jvm.Functions.IFunction2! tabs, AndroidX.Compose.Runtime.IComposer? _composer, int selectedTabIndex, int _changed) -> void
+static AndroidX.Compose.Material3.TabRowKt.SecondaryTabRow(int p0, AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, Kotlin.Jvm.Functions.IFunction3? indicator, Kotlin.Jvm.Functions.IFunction2? divider, Kotlin.Jvm.Functions.IFunction2! tabs, AndroidX.Compose.Runtime.IComposer? _composer, int selectedTabIndex, int _changed) -> void
+static AndroidX.Compose.Material3.TabRowKt.TabRow(int p0, AndroidX.Compose.UI.IModifier? modifier, long containerColor, long contentColor, Kotlin.Jvm.Functions.IFunction3? indicator, Kotlin.Jvm.Functions.IFunction2? divider, Kotlin.Jvm.Functions.IFunction2! tabs, AndroidX.Compose.Runtime.IComposer? _composer, int selectedTabIndex, int _changed) -> void
 static AndroidX.Compose.Material3.TextFieldDefaults.Instance.get -> AndroidX.Compose.Material3.TextFieldDefaults!
+static AndroidX.Compose.Material3.TextFieldKt.TextField(AndroidX.Compose.Foundation.Text.Input.TextFieldState! state, AndroidX.Compose.UI.IModifier? modifier, bool enabled, bool readOnly, AndroidX.Compose.UI.Text.TextStyle? textStyle, AndroidX.Compose.Material3.TextFieldLabelPosition? labelPosition, Kotlin.Jvm.Functions.IFunction3? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.Foundation.Text.Input.IInputTransformation? inputTransformation, AndroidX.Compose.Foundation.Text.Input.IOutputTransformation? outputTransformation, AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions, AndroidX.Compose.Foundation.Text.Input.IKeyboardActionHandler? onKeyboardAction, AndroidX.Compose.Foundation.Text.Input.ITextFieldLineLimits? lineLimits, Kotlin.Jvm.Functions.IFunction2? onTextLayout, AndroidX.Compose.Foundation.ScrollState? scrollState, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Foundation.Layout.IPaddingValues? contentPadding, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int p26, int _changed, int _changed1, int _changed2) -> void
+static AndroidX.Compose.Material3.TextFieldKt.TextField(AndroidX.Compose.UI.Text.Input.TextFieldValue! value, Kotlin.Jvm.Functions.IFunction1! onValueChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, bool readOnly, AndroidX.Compose.UI.Text.TextStyle? textStyle, Kotlin.Jvm.Functions.IFunction2? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.UI.Text.Input.IVisualTransformation? visualTransformation, AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions, AndroidX.Compose.Foundation.Text.KeyboardActions? keyboardActions, bool singleLine, int p18, int maxLines, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Runtime.IComposer? _composer, int minLines, int _changed, int _changed1, int _changed2) -> void
+static AndroidX.Compose.Material3.TextFieldKt.TextField(string! value, Kotlin.Jvm.Functions.IFunction1! onValueChange, AndroidX.Compose.UI.IModifier? modifier, bool enabled, bool readOnly, AndroidX.Compose.UI.Text.TextStyle? textStyle, Kotlin.Jvm.Functions.IFunction2? label, Kotlin.Jvm.Functions.IFunction2? placeholder, Kotlin.Jvm.Functions.IFunction2? leadingIcon, Kotlin.Jvm.Functions.IFunction2? trailingIcon, Kotlin.Jvm.Functions.IFunction2? prefix, Kotlin.Jvm.Functions.IFunction2? suffix, Kotlin.Jvm.Functions.IFunction2? supportingText, bool isError, AndroidX.Compose.UI.Text.Input.IVisualTransformation? visualTransformation, AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions, AndroidX.Compose.Foundation.Text.KeyboardActions? keyboardActions, bool singleLine, int p18, int maxLines, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.TextFieldColors? colors, AndroidX.Compose.Runtime.IComposer? _composer, int minLines, int _changed, int _changed1, int _changed2) -> void
 static AndroidX.Compose.Material3.TextFieldKt.TextFieldWithLabelVerticalPadding.get -> float
+static AndroidX.Compose.Material3.TextKt.LocalTextStyle.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.TextKt.ProvideTextStyle(AndroidX.Compose.UI.Text.TextStyle! value, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> void
+static AndroidX.Compose.Material3.TextKt.Text(AndroidX.Compose.UI.Text.AnnotatedString! text, AndroidX.Compose.UI.IModifier? modifier, long color, AndroidX.Compose.Foundation.Text.ITextAutoSize? autoSize, long fontSize, AndroidX.Compose.UI.Text.Font.FontStyle? fontStyle, AndroidX.Compose.UI.Text.Font.FontWeight? fontWeight, AndroidX.Compose.UI.Text.Font.FontFamily? fontFamily, long letterSpacing, AndroidX.Compose.UI.Text.Style.TextDecoration? textDecoration, AndroidX.Compose.UI.Text.Style.TextAlign? textAlign, long lineHeight, int p12, bool softWrap, int overflow, int maxLines, System.Collections.Generic.IDictionary<string!, AndroidX.Compose.Foundation.Text.InlineTextContent!>? inlineContent, Kotlin.Jvm.Functions.IFunction1? onTextLayout, AndroidX.Compose.UI.Text.TextStyle? style, AndroidX.Compose.Runtime.IComposer? _composer, int minLines, int _changed, int _changed1) -> void
+static AndroidX.Compose.Material3.TextKt.Text(string! text, AndroidX.Compose.UI.IModifier? modifier, long color, AndroidX.Compose.Foundation.Text.ITextAutoSize? autoSize, long fontSize, AndroidX.Compose.UI.Text.Font.FontStyle? fontStyle, AndroidX.Compose.UI.Text.Font.FontWeight? fontWeight, AndroidX.Compose.UI.Text.Font.FontFamily? fontFamily, long letterSpacing, AndroidX.Compose.UI.Text.Style.TextDecoration? textDecoration, AndroidX.Compose.UI.Text.Style.TextAlign? textAlign, long lineHeight, int p12, bool softWrap, int overflow, int maxLines, Kotlin.Jvm.Functions.IFunction1? onTextLayout, AndroidX.Compose.UI.Text.TextStyle? style, AndroidX.Compose.Runtime.IComposer? _composer, int minLines, int _changed, int _changed1) -> void
 static AndroidX.Compose.Material3.TimeFormat_androidKt.Is24HourFormat(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> bool
 static AndroidX.Compose.Material3.TimePickerDefaults.Instance.get -> AndroidX.Compose.Material3.TimePickerDefaults!
 static AndroidX.Compose.Material3.TimePickerDialogDefaults.Instance.get -> AndroidX.Compose.Material3.TimePickerDialogDefaults!
+static AndroidX.Compose.Material3.TimePickerDialogKt.TimePickerDialog(Kotlin.Jvm.Functions.IFunction0! onDismissRequest, Kotlin.Jvm.Functions.IFunction2! confirmButton, Kotlin.Jvm.Functions.IFunction2! title, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Window.DialogProperties? properties, Kotlin.Jvm.Functions.IFunction2? modeToggleButton, Kotlin.Jvm.Functions.IFunction2? dismissButton, AndroidX.Compose.UI.Graphics.IShape? shape, long containerColor, Kotlin.Jvm.Functions.IFunction3! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
 static AndroidX.Compose.Material3.TimePickerKt.ClockDialMinContainerSize.get -> float
 static AndroidX.Compose.Material3.TimePickerKt.GetDefaultTimePickerLayoutType(AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> int
 static AndroidX.Compose.Material3.TimePickerKt.GetHourForDisplay(AndroidX.Compose.Material3.ITimePickerState! obj) -> int
 static AndroidX.Compose.Material3.TimePickerKt.GetSelectorPos(Java.Lang.Object! obj) -> long
 static AndroidX.Compose.Material3.TimePickerKt.IsPm(AndroidX.Compose.Material3.ITimePickerState! obj) -> bool
 static AndroidX.Compose.Material3.TimePickerKt.RememberTimePickerState(int p0, int initialHour, bool is24Hour, AndroidX.Compose.Runtime.IComposer? _composer, int initialMinute, int _changed) -> AndroidX.Compose.Material3.ITimePickerState!
+static AndroidX.Compose.Material3.TimePickerKt.TimeInput(AndroidX.Compose.Material3.ITimePickerState! state, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.TimePickerColors? colors, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> void
+static AndroidX.Compose.Material3.TimePickerKt.TimePicker(AndroidX.Compose.Material3.ITimePickerState! state, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.TimePickerColors? colors, int p3, AndroidX.Compose.Runtime.IComposer? _composer, int layoutType, int _changed) -> void
 static AndroidX.Compose.Material3.TimePickerKt.TimePickerState(int initialHour, int initialMinute, bool is24Hour) -> AndroidX.Compose.Material3.ITimePickerState!
+static AndroidX.Compose.Material3.Tokens.TypographyTokensKt.DefaultLineHeightStyle.get -> AndroidX.Compose.UI.Text.Style.LineHeightStyle!
+static AndroidX.Compose.Material3.Tokens.TypographyTokensKt.DefaultTextStyle.get -> AndroidX.Compose.UI.Text.TextStyle!
 static AndroidX.Compose.Material3.TonalPaletteKt.BaselineTonalPalette.get -> Java.Lang.Object!
 static AndroidX.Compose.Material3.TooltipDefaults.Instance.get -> AndroidX.Compose.Material3.TooltipDefaults!
 static AndroidX.Compose.Material3.TooltipKt.ActionLabelBottomPadding.get -> float
 static AndroidX.Compose.Material3.TooltipKt.ActionLabelMinHeight.get -> float
 static AndroidX.Compose.Material3.TooltipKt.HeightToSubheadFirstLine.get -> float
+static AndroidX.Compose.Material3.TooltipKt.PlainTooltip(AndroidX.Compose.Material3.ITooltipScope! obj, AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.UI.Graphics.IShape? caretShape, float maxWidth, AndroidX.Compose.UI.Graphics.IShape? shape, long contentColor, long containerColor, float tonalElevation, float shadowElevation, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p11, int _changed) -> void
+static AndroidX.Compose.Material3.TooltipKt.PlainTooltipContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues!
+static AndroidX.Compose.Material3.TooltipKt.RememberTooltipState(bool initialIsVisible, bool isPersistent, AndroidX.Compose.Foundation.MutatorMutex? mutatorMutex, AndroidX.Compose.Runtime.IComposer? _composer, int p4, int _changed) -> AndroidX.Compose.Material3.ITooltipState!
+static AndroidX.Compose.Material3.TooltipKt.RichTooltip(AndroidX.Compose.Material3.ITooltipScope! obj, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction2? title, Kotlin.Jvm.Functions.IFunction2? action, AndroidX.Compose.UI.Graphics.IShape? caretShape, float maxWidth, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.RichTooltipColors? colors, float tonalElevation, float shadowElevation, Kotlin.Jvm.Functions.IFunction2! text, AndroidX.Compose.Runtime.IComposer? _composer, int p12, int _changed, int _changed1) -> void
 static AndroidX.Compose.Material3.TooltipKt.RichTooltipHorizontalPadding.get -> float
 static AndroidX.Compose.Material3.TooltipKt.SpacingBetweenTooltipAndAnchor.get -> float
+static AndroidX.Compose.Material3.TooltipKt.TooltipBox(AndroidX.Compose.UI.Window.IPopupPositionProvider! positionProvider, Kotlin.Jvm.Functions.IFunction3! tooltip, AndroidX.Compose.Material3.ITooltipState! state, AndroidX.Compose.UI.IModifier? modifier, Kotlin.Jvm.Functions.IFunction0? onDismissRequest, bool focusable, bool enableUserInput, bool hasAction, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p10, int _changed) -> void
 static AndroidX.Compose.Material3.TooltipKt.TooltipMinHeight.get -> float
 static AndroidX.Compose.Material3.TooltipKt.TooltipMinWidth.get -> float
+static AndroidX.Compose.Material3.TooltipKt.TooltipState(bool initialIsVisible, bool isPersistent, AndroidX.Compose.Foundation.MutatorMutex! mutatorMutex) -> AndroidX.Compose.Material3.ITooltipState!
 static AndroidX.Compose.Material3.TopAppBarDefaults.Instance.get -> AndroidX.Compose.Material3.TopAppBarDefaults!
+static AndroidX.Compose.Material3.TypographyKt.GetValue(Java.Lang.Enum! obj, AndroidX.Compose.Runtime.IComposer? _composer, int _changed) -> AndroidX.Compose.UI.Text.TextStyle!
 static AndroidX.Compose.Material3.TypographyKt.LocalTypography.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
 static AndroidX.Compose.Material3.VerticalDragHandleDefaults.Instance.get -> AndroidX.Compose.Material3.VerticalDragHandleDefaults!
 static AndroidX.Compose.Material3.WideNavigationRailDefaults.Instance.get -> AndroidX.Compose.Material3.WideNavigationRailDefaults!
 static AndroidX.Compose.Material3.WideNavigationRailItemDefaults.Instance.get -> AndroidX.Compose.Material3.WideNavigationRailItemDefaults!
 static AndroidX.Compose.Material3.WideNavigationRailKt.LocalModalWideNavigationRailOverride.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
 static AndroidX.Compose.Material3.WideNavigationRailKt.LocalWideNavigationRailOverride.get -> AndroidX.Compose.Runtime.ProvidableCompositionLocal!
+static AndroidX.Compose.Material3.WideNavigationRailKt.ModalWideNavigationRail(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.IWideNavigationRailState? state, bool hideOnCollapse, AndroidX.Compose.UI.Graphics.IShape? collapsedShape, AndroidX.Compose.UI.Graphics.IShape? expandedShape, AndroidX.Compose.Material3.WideNavigationRailColors? colors, Kotlin.Jvm.Functions.IFunction2? header, float expandedHeaderTopPadding, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Foundation.Layout.Arrangement.IVertical? arrangement, AndroidX.Compose.Material3.ModalWideNavigationRailProperties? expandedProperties, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p13, int _changed, int _changed1) -> void
 static AndroidX.Compose.Material3.WideNavigationRailKt.WNRItemNoLabelIndicatorPadding.get -> float
+static AndroidX.Compose.Material3.WideNavigationRailKt.WideNavigationRail(AndroidX.Compose.UI.IModifier? modifier, AndroidX.Compose.Material3.IWideNavigationRailState? state, AndroidX.Compose.UI.Graphics.IShape? shape, AndroidX.Compose.Material3.WideNavigationRailColors? colors, Kotlin.Jvm.Functions.IFunction2? header, AndroidX.Compose.Foundation.Layout.IWindowInsets? windowInsets, AndroidX.Compose.Foundation.Layout.Arrangement.IVertical? arrangement, Kotlin.Jvm.Functions.IFunction2! content, AndroidX.Compose.Runtime.IComposer? _composer, int p9, int _changed) -> void
+static AndroidX.Compose.Material3.WideNavigationRailKt.WideNavigationRailItem(bool selected, Kotlin.Jvm.Functions.IFunction0! onClick, Kotlin.Jvm.Functions.IFunction2! icon, Kotlin.Jvm.Functions.IFunction2? label, bool railExpanded, AndroidX.Compose.UI.IModifier? modifier, bool enabled, int p7, AndroidX.Compose.Material3.NavigationItemColors? colors, AndroidX.Compose.Foundation.Interaction.IMutableInteractionSource? interactionSource, AndroidX.Compose.Runtime.IComposer? _composer, int iconPosition, int _changed) -> void
 static AndroidX.Compose.Material3.WideNavigationRailStateKt.IsExpanded(AndroidX.Compose.Material3.WideNavigationRailValue! obj) -> bool
 static AndroidX.Compose.Material3.WideNavigationRailStateKt.RememberWideNavigationRailState(AndroidX.Compose.Material3.WideNavigationRailValue? initialValue, AndroidX.Compose.Runtime.IComposer? _composer, int p2, int _changed) -> AndroidX.Compose.Material3.IWideNavigationRailState!
 static AndroidX.Compose.Material3.WideNavigationRailValue.Collapsed.get -> AndroidX.Compose.Material3.WideNavigationRailValue?


### PR DESCRIPTION
Fixes #1452.

## What's happening

When `Xamarin.AndroidX.Compose.Material3Android 1.4.0.3` was packaged in #1418, several of its Compose dependencies were still empty facades. Real bindings for `Compose.UI.Graphics`, `Compose.UI.Text`, `Compose.UI.Unit`, and parts of `Compose.Foundation` were un-stripped *after* that release in #1438, #1440, #1448, #1454, and #1458.

In particular, `androidx.compose.foundation.shape.CornerBasedShape` was not resolvable to the binding generator at the time `material3-android` was built, so **the generator silently dropped every member that referenced it** — including the `Shapes(extraSmall, small, medium, large, extraLarge)` secondary constructor reported in #1452, the `Shapes.{ExtraSmall, Small, Medium, Large, ExtraLarge}` properties, `Shapes.Copy(...)`, and the `*Defaults.GetShape(...)` / `SegmentedButtonDefaults.GetBaseShape(...)` accessors across the package.

## Evidence

Same source, just a rebuild against the current dependency graph:

| | Published 1.4.0.3 `Shapes` | Fresh build (1.4.0.4) `Shapes` |
| --- | --- | --- |
| References to `CornerBasedShape` | 0 | 27 |
| Public members | `Shapes()` only | `Shapes()`, `Shapes(CornerBasedShape × 5)`, `ExtraSmall`, `Small`, `Medium`, `Large`, `ExtraLarge`, `Copy(CornerBasedShape × 5)`, … |

(Note: the issue was filed against `ShapesKt.Shapes(...)` — that top-level Kotlin function does not exist upstream. The actual missing API is the secondary constructor `new Shapes(extraSmall, small, medium, large, extraLarge)` on the `Shapes` class. The reporter's recommended call site, `Shapes(extraSmall = ..., small = ..., ...)`, will work once this constructor is bound.)

## What this PR does

- **`config.json`**: bumps `material3-android` `nugetVersion` `1.4.0.3` → `1.4.0.4` so the rebuilt assembly actually ships.
- **`source/androidx.compose.material3/material3-android/PublicAPI/PublicAPI.Unshipped.txt`**: records the ~446 newly-bound members. This file is auto-regenerated by `Mono.ApiTools.MSBuildTasks` via `_GeneratePublicApiFiles` in `Directory.Build.targets`; the diff is just the `PublicApiAnalyzer` baseline catching up to reality.

No source-level transforms or `Metadata.xml` changes are needed — rebuilding against the now-real Compose dependencies is the actual fix.