### PR TITLE
Scope ANDROID_TEAM_PAT to weekly-stable-updates environment

### DIFF
--- a/.github/workflows/weekly-stable-updates.yml
+++ b/.github/workflows/weekly-stable-updates.yml
@@ -12,7 +12,8 @@ on:
 jobs:
   create-weekly-issue:
     runs-on: ubuntu-latest
-    
+    environment: weekly-stable-updates
+
     steps:
     - name: Get current date
       id: date


### PR DESCRIPTION
Our `ANDROID_TEAM_PAT` secret needs to live behind an environment so we can apply protection rules (reviewers, branch restrictions, etc.) instead of exposing it as a plain repo-level secret to every workflow.

This adds `environment: weekly-stable-updates` to the `create-weekly-issue` job in `.github/workflows/weekly-stable-updates.yml`. The existing `${{ secrets.ANDROID_TEAM_PAT }}` reference now resolves from that environment's secret store.

**Follow-up required before this is functional:** create a `weekly-stable-updates` environment in repo Settings -> Environments and add the `ANDROID_TEAM_PAT` secret there. Until that's done, the "Assign issue to Copilot" step will fail to authenticate.