### PR TITLE
Enable real signing on main branch

### DIFF
--- a/build/ci/stage-sign-artifacts.yml
+++ b/build/ci/stage-sign-artifacts.yml
@@ -14,7 +14,7 @@ stages:
       artifactName: output-windows
       usePipelineArtifactTasks: true
       checkoutType: self
-      ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), not(eq(variables['Build.Reason'], 'PullRequest'))) }}:
+      ${{ if and(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')), not(eq(variables['Build.Reason'], 'PullRequest'))) }}:
         signType: Real
       ${{ else }}:
         signType: Test

--- a/build/ci/stage-sign-artifacts.yml
+++ b/build/ci/stage-sign-artifacts.yml
@@ -1,5 +1,5 @@
-# Signs artifacts on tags built for release
-  
+# Signs artifacts on release/* branches and non-scheduled main builds
+
 stages:
 - stage: sign_artifacts
   displayName: Sign Artifacts
@@ -14,7 +14,7 @@ stages:
       artifactName: output-windows
       usePipelineArtifactTasks: true
       checkoutType: self
-      ${{ if and(or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')), not(eq(variables['Build.Reason'], 'PullRequest'))) }}:
+      ${{ if and(or(and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'Schedule')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')), not(eq(variables['Build.Reason'], 'PullRequest'))) }}:
         signType: Real
       ${{ else }}:
         signType: Test


### PR DESCRIPTION
Currently `build/ci/stage-sign-artifacts.yml` only requests `signType: Real` for non-PR builds of `release/*` branches; everything else (including `main`) signs with `Test`. To enable shipping directly out of `main`, this expands the condition so non-PR builds of `main` also produce real-signed artifacts.

PR builds remain test-signed regardless of target branch.