### PR TITLE
Use Claude Opus 4.8 for weekly stable updates agent

### DIFF
--- a/.github/workflows/weekly-stable-updates.yml
+++ b/.github/workflows/weekly-stable-updates.yml
@@ -75,7 +75,7 @@ jobs:
           console.log(`Created issue #${response.data.number}: ${response.data.title}`);
           core.setOutput('issue-number', response.data.number);
 
-    - name: Assign issue to Copilot with Claude Opus 4.6
+    - name: Assign issue to Copilot
       if: steps.create-issue.outputs.issue-number && steps.create-issue.outputs.issue-number != ''
       run: |
         gh api \
@@ -86,7 +86,7 @@ jobs:
           --input - <<< '{
           "assignees": ["copilot-swe-agent[bot]"],
           "agent_assignment": {
-            "model": "claude-opus-4.6"
+            "model": "claude-opus-4.8"
           }
         }'
       env:


### PR DESCRIPTION
Bumps the Copilot coding agent model used by the weekly stable updates workflow from `claude-opus-4.6` to `claude-opus-4.8`.

Notes:
- `claude-opus-4.8` is not in the currently documented model list at https://docs.github.com/en/rest/agent-tasks/agent-tasks (which still lists `claude-opus-4.6` as the latest Opus). The docs explicitly call out that "the allowed models may change over time and depend on the user's GitHub Copilot plan and organization policies," so we're trying it empirically; if the assignment API rejects it we can revert.
- Also dropped the model version from the step name (now just "Assign issue to Copilot") so it doesn't drift out of sync on future bumps.