### PR TITLE
20260626 alignment bumps

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,49 +12,49 @@
         "groupId": "androidx.activity",
         "artifactId": "activity",
         "version": "1.13.0",
-        "nugetVersion": "1.13.0",
+        "nugetVersion": "1.13.0.1",
         "nugetId": "Xamarin.AndroidX.Activity"
       },
       {
         "groupId": "androidx.activity",
         "artifactId": "activity-compose",
         "version": "1.13.0",
-        "nugetVersion": "1.13.0",
+        "nugetVersion": "1.13.0.1",
         "nugetId": "Xamarin.AndroidX.Activity.Compose"
       },
       {
         "groupId": "androidx.activity",
         "artifactId": "activity-ktx",
         "version": "1.13.0",
-        "nugetVersion": "1.13.0",
+        "nugetVersion": "1.13.0.1",
         "nugetId": "Xamarin.AndroidX.Activity.Ktx"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.35-alpha05",
+        "nugetVersion": "1.0.0.36-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.Identifier"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-common",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.35-alpha05",
+        "nugetVersion": "1.0.0.36-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierCommon"
       },
       {
         "groupId": "androidx.ads",
         "artifactId": "ads-identifier-provider",
         "version": "1.0.0-alpha05",
-        "nugetVersion": "1.0.0.35-alpha05",
+        "nugetVersion": "1.0.0.36-alpha05",
         "nugetId": "Xamarin.AndroidX.Ads.IdentifierProvider"
       },
       {
         "groupId": "androidx.annotation",
         "artifactId": "annotation",
         "version": "1.10.0",
-        "nugetVersion": "1.10.0",
+        "nugetVersion": "1.10.0.1",
         "nugetId": "Xamarin.AndroidX.Annotation",
         "extraDependencies": "androidx.annotation.annotation-jvm"
       },
@@ -62,210 +62,210 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation-experimental",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Annotation.Experimental"
       },
       {
         "groupId": "androidx.annotation",
         "artifactId": "annotation-jvm",
         "version": "1.10.0",
-        "nugetVersion": "1.10.0",
+        "nugetVersion": "1.10.0.1",
         "nugetId": "Xamarin.AndroidX.Annotation.Jvm"
       },
       {
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1.3",
+        "nugetVersion": "1.7.1.4",
         "nugetId": "Xamarin.AndroidX.AppCompat"
       },
       {
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat-resources",
         "version": "1.7.1",
-        "nugetVersion": "1.7.1.3",
+        "nugetVersion": "1.7.1.4",
         "nugetId": "Xamarin.AndroidX.AppCompat.AppCompatResources"
       },
       {
         "groupId": "androidx.arch.core",
         "artifactId": "core-common",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.20",
+        "nugetVersion": "2.2.0.21",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Common"
       },
       {
         "groupId": "androidx.arch.core",
         "artifactId": "core-runtime",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.20",
+        "nugetVersion": "2.2.0.21",
         "nugetId": "Xamarin.AndroidX.Arch.Core.Runtime"
       },
       {
         "groupId": "androidx.asynclayoutinflater",
         "artifactId": "asynclayoutinflater",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.AsyncLayoutInflater"
       },
       {
         "groupId": "androidx.autofill",
         "artifactId": "autofill",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.3",
+        "nugetVersion": "1.3.0.4",
         "nugetId": "Xamarin.AndroidX.AutoFill"
       },
       {
         "groupId": "androidx.biometric",
         "artifactId": "biometric",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.32",
+        "nugetVersion": "1.1.0.33",
         "nugetId": "Xamarin.AndroidX.Biometric"
       },
       {
         "groupId": "androidx.browser",
         "artifactId": "browser",
         "version": "1.10.0",
-        "nugetVersion": "1.10.0",
+        "nugetVersion": "1.10.0.1",
         "nugetId": "Xamarin.AndroidX.Browser"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-camera2",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-camera2-pipe",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.Camera2.Pipe"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-core",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.Core"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-effects",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.Effects"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-extensions",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.Extensions"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-lifecycle",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.Lifecycle"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-mlkit-vision",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.MLKit.Vision"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-video",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.Video"
       },
       {
         "groupId": "androidx.camera",
         "artifactId": "camera-view",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.View"
       },
       {
         "groupId": "androidx.camera.featurecombinationquery",
         "artifactId": "featurecombinationquery",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.FeatureCombinationQuery"
       },
       {
         "groupId": "androidx.camera.viewfinder",
         "artifactId": "viewfinder-core",
         "version": "1.6.1",
-        "nugetVersion": "1.6.1",
+        "nugetVersion": "1.6.1.1",
         "nugetId": "Xamarin.AndroidX.Camera.Viewfinder.Core"
       },
       {
         "groupId": "androidx.car",
         "artifactId": "car",
         "version": "1.0.0-alpha7",
-        "nugetVersion": "1.0.0.34-alpha7",
+        "nugetVersion": "1.0.0.35-alpha7",
         "nugetId": "Xamarin.AndroidX.Car.Car"
       },
       {
         "groupId": "androidx.car",
         "artifactId": "car-cluster",
         "version": "1.0.0-alpha5",
-        "nugetVersion": "1.0.0.34-alpha5",
+        "nugetVersion": "1.0.0.35-alpha5",
         "nugetId": "Xamarin.AndroidX.Car.Cluster"
       },
       {
         "groupId": "androidx.car.app",
         "artifactId": "app",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.3",
+        "nugetVersion": "1.7.0.4",
         "nugetId": "Xamarin.AndroidX.Car.App.App"
       },
       {
         "groupId": "androidx.cardview",
         "artifactId": "cardview",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.38",
+        "nugetVersion": "1.0.0.39",
         "nugetId": "Xamarin.AndroidX.CardView"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Collection"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection-jvm",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Collection.Jvm"
       },
       {
         "groupId": "androidx.collection",
         "artifactId": "collection-ktx",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Collection.Ktx"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Android",
         "extraDependencies": "androidx.compose.ui.ui-unit-android"
       },
@@ -273,14 +273,14 @@
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-core-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Core.Android",
         "extraDependencies": "org.jetbrains.kotlinx.kotlinx-coroutines-core-jvm"
       },
@@ -288,119 +288,119 @@
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics"
       },
       {
         "groupId": "androidx.compose.animation",
         "artifactId": "animation-graphics-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Animation.Graphics.Android"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Android"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout"
       },
       {
         "groupId": "androidx.compose.foundation",
         "artifactId": "foundation-layout-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Foundation.Layout.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.6",
+        "nugetVersion": "1.7.8.7",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-core-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.6",
+        "nugetVersion": "1.7.8.7",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Core.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.5",
+        "nugetVersion": "1.7.8.6",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-icons-extended-android",
         "version": "1.7.8",
-        "nugetVersion": "1.7.8.5",
+        "nugetVersion": "1.7.8.6",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Icons.Extended.Android"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple"
       },
       {
         "groupId": "androidx.compose.material",
         "artifactId": "material-ripple-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material.Ripple.Android"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.2",
+        "nugetVersion": "1.4.0.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material3"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-adaptive-navigation-suite",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.Adaptive.NavigationSuite"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-adaptive-navigation-suite-android",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.Adaptive.NavigationSuiteAndroid",
         "extraDependencies": "androidx.compose.runtime.runtime-android,androidx.compose.ui.ui-android,androidx.compose.foundation.foundation-android,androidx.compose.foundation.foundation-layout-android"
       },
@@ -408,35 +408,35 @@
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-android",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.4",
+        "nugetVersion": "1.4.0.5",
         "nugetId": "Xamarin.AndroidX.Compose.Material3Android"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-window-size-class",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.2",
+        "nugetVersion": "1.4.0.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.WindowSizeClass"
       },
       {
         "groupId": "androidx.compose.material3",
         "artifactId": "material3-window-size-class-android",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.2",
+        "nugetVersion": "1.4.0.3",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.WindowSizeClassAndroid"
       },
       {
         "groupId": "androidx.compose.material3.adaptive",
         "artifactId": "adaptive",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.Adaptive"
       },
       {
         "groupId": "androidx.compose.material3.adaptive",
         "artifactId": "adaptive-android",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.AdaptiveAndroid",
         "extraDependencies": "androidx.compose.runtime.runtime-android"
       },
@@ -444,14 +444,14 @@
         "groupId": "androidx.compose.material3.adaptive",
         "artifactId": "adaptive-layout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.Adaptive.Layout"
       },
       {
         "groupId": "androidx.compose.material3.adaptive",
         "artifactId": "adaptive-layout-android",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.Adaptive.LayoutAndroid",
         "extraDependencies": "androidx.compose.ui.ui-unit-android"
       },
@@ -459,14 +459,14 @@
         "groupId": "androidx.compose.material3.adaptive",
         "artifactId": "adaptive-navigation",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.Adaptive.Navigation"
       },
       {
         "groupId": "androidx.compose.material3.adaptive",
         "artifactId": "adaptive-navigation-android",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.1",
         "nugetId": "Xamarin.AndroidX.Compose.Material3.Adaptive.NavigationAndroid",
         "extraDependencies": "androidx.compose.runtime.runtime-android,androidx.compose.ui.ui-android"
       },
@@ -474,21 +474,21 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Android"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-annotation",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Annotation",
         "excludedRuntimeDependencies": "androidx.compose.runtime.runtime-annotation-jvm",
         "type": "no-bindings"
@@ -497,7 +497,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-annotation-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Annotation.Android",
         "type": "no-bindings"
       },
@@ -505,7 +505,7 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-annotation-jvm",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm",
         "type": "no-bindings"
       },
@@ -513,315 +513,315 @@
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-livedata",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.LiveData"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-retain",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Retain"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-retain-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Retain.Android"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava2",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava2"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava2-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava2.Android"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava3",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava3"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-rxjava3-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.RxJava3.Android"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable"
       },
       {
         "groupId": "androidx.compose.runtime",
         "artifactId": "runtime-saveable-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.Runtime.Saveable.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-geometry-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Geometry.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-graphics-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Graphics.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-text-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Text.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-data-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Data.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-tooling-preview-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Tooling.Preview.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-unit-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Unit.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-util-android",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.Util.Android"
       },
       {
         "groupId": "androidx.compose.ui",
         "artifactId": "ui-viewbinding",
         "version": "1.11.3",
-        "nugetVersion": "1.11.3",
+        "nugetVersion": "1.11.3.1",
         "nugetId": "Xamarin.AndroidX.Compose.UI.ViewBinding"
       },
       {
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.3",
+        "nugetVersion": "1.3.0.4",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures"
       },
       {
         "groupId": "androidx.concurrent",
         "artifactId": "concurrent-futures-ktx",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.3",
+        "nugetVersion": "1.3.0.4",
         "nugetId": "Xamarin.AndroidX.Concurrent.Futures.Ktx"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout",
         "version": "2.2.1",
-        "nugetVersion": "2.2.1.5",
+        "nugetVersion": "2.2.1.6",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-core",
         "version": "1.1.1",
-        "nugetVersion": "1.1.1.5",
+        "nugetVersion": "1.1.1.6",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Core"
       },
       {
         "groupId": "androidx.constraintlayout",
         "artifactId": "constraintlayout-solver",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4.31",
+        "nugetVersion": "2.0.4.32",
         "nugetId": "Xamarin.AndroidX.ConstraintLayout.Solver"
       },
       {
         "groupId": "androidx.contentpager",
         "artifactId": "contentpager",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.ContentPager"
       },
       {
         "groupId": "androidx.coordinatorlayout",
         "artifactId": "coordinatorlayout",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.5",
+        "nugetVersion": "1.3.0.6",
         "nugetId": "Xamarin.AndroidX.CoordinatorLayout"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core",
         "version": "1.19.0",
-        "nugetVersion": "1.19.0",
+        "nugetVersion": "1.19.0.1",
         "nugetId": "Xamarin.AndroidX.Core"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-animation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.10",
+        "nugetVersion": "1.0.0.11",
         "nugetId": "Xamarin.AndroidX.Core.Animation"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-backported-fixes",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0",
+        "nugetVersion": "1.0.0.1",
         "nugetId": "Xamarin.AndroidX.Core.BackportedFixes"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-google-shortcuts",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.21",
+        "nugetVersion": "1.1.0.22",
         "nugetId": "Xamarin.AndroidX.Core.GoogleShortcuts"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-ktx",
         "version": "1.19.0",
-        "nugetVersion": "1.19.0",
+        "nugetVersion": "1.19.0.1",
         "nugetId": "Xamarin.AndroidX.Core.Core.Ktx"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-role",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.Core.Role"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-splashscreen",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.2",
+        "nugetVersion": "1.2.0.3",
         "nugetId": "Xamarin.AndroidX.Core.SplashScreen"
       },
       {
         "groupId": "androidx.core",
         "artifactId": "core-viewtree",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.5",
+        "nugetVersion": "1.0.0.6",
         "nugetId": "Xamarin.AndroidX.Core.ViewTree"
       },
       {
         "groupId": "androidx.credentials",
         "artifactId": "credentials",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Credentials"
       },
       {
         "groupId": "androidx.credentials",
         "artifactId": "credentials-play-services-auth",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Credentials.PlayServicesAuth",
         "allowPrereleaseDependencies": true
       },
@@ -829,84 +829,84 @@
         "groupId": "androidx.cursoradapter",
         "artifactId": "cursoradapter",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.CursorAdapter"
       },
       {
         "groupId": "androidx.customview",
         "artifactId": "customview",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.3",
+        "nugetVersion": "1.2.0.4",
         "nugetId": "Xamarin.AndroidX.CustomView"
       },
       {
         "groupId": "androidx.customview",
         "artifactId": "customview-poolingcontainer",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.CustomView.PoolingContainer"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-adapters",
         "version": "9.2.1",
-        "nugetVersion": "9.2.1",
+        "nugetVersion": "9.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingAdapters"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-common",
         "version": "9.2.1",
-        "nugetVersion": "9.2.1",
+        "nugetVersion": "9.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingCommon"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "databinding-runtime",
         "version": "9.2.1",
-        "nugetVersion": "9.2.1",
+        "nugetVersion": "9.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.DataBindingRuntime"
       },
       {
         "groupId": "androidx.databinding",
         "artifactId": "viewbinding",
         "version": "9.2.1",
-        "nugetVersion": "9.2.1",
+        "nugetVersion": "9.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataBinding.ViewBinding"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-android",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-android",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-jvm",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.Jvm",
         "extraDependencies": "androidx.datastore.datastore-core-android",
         "comments": "Empty package we want to redirect to Xamarin.AndroidX.DataStore.Core.Android because it is a superset of this package, causing conflicts."
@@ -915,35 +915,35 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-okio",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.OkIO"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-core-okio-jvm",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Core.OkIO.Jvm"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-android",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core",
         "excludedRuntimeDependencies": "androidx.datastore.datastore-preferences-core-jvm"
       },
@@ -951,105 +951,105 @@
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core-android",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core.Android"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-core-jvm",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Core.Jvm"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-external-protobuf",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.External.Protobuf"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-preferences-proto",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.Preferences.Proto"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava2",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava2"
       },
       {
         "groupId": "androidx.datastore",
         "artifactId": "datastore-rxjava3",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.AndroidX.DataStore.RxJava3"
       },
       {
         "groupId": "androidx.documentfile",
         "artifactId": "documentfile",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.DocumentFile"
       },
       {
         "groupId": "androidx.drawerlayout",
         "artifactId": "drawerlayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.20",
+        "nugetVersion": "1.2.0.21",
         "nugetId": "Xamarin.AndroidX.DrawerLayout"
       },
       {
         "groupId": "androidx.dynamicanimation",
         "artifactId": "dynamicanimation",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.DynamicAnimation"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.2",
+        "nugetVersion": "1.2.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji-appcompat",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.2",
+        "nugetVersion": "1.2.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji.AppCompat"
       },
       {
         "groupId": "androidx.emoji",
         "artifactId": "emoji-bundled",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.2",
+        "nugetVersion": "1.2.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji.Bundled"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.2",
+        "nugetVersion": "1.6.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji2"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-bundled",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.2",
+        "nugetVersion": "1.6.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji2.Bundled"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-emojipicker",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.2",
+        "nugetVersion": "1.6.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji2.EmojiPicker",
         "skipExtendedTests": true,
         "comments": "Skip tests due to explicit dependency version request causes conflicts"
@@ -1058,658 +1058,658 @@
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-views",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.2",
+        "nugetVersion": "1.6.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji2.Views"
       },
       {
         "groupId": "androidx.emoji2",
         "artifactId": "emoji2-views-helper",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.2",
+        "nugetVersion": "1.6.0.3",
         "nugetId": "Xamarin.AndroidX.Emoji2.ViewsHelper"
       },
       {
         "groupId": "androidx.enterprise",
         "artifactId": "enterprise-feedback",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.22",
+        "nugetVersion": "1.1.0.23",
         "nugetId": "Xamarin.AndroidX.Enterprise.Feedback"
       },
       {
         "groupId": "androidx.exifinterface",
         "artifactId": "exifinterface",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2.2",
+        "nugetVersion": "1.4.2.3",
         "nugetId": "Xamarin.AndroidX.ExifInterface"
       },
       {
         "groupId": "androidx.fragment",
         "artifactId": "fragment",
         "version": "1.8.9",
-        "nugetVersion": "1.8.9.2",
+        "nugetVersion": "1.8.9.3",
         "nugetId": "Xamarin.AndroidX.Fragment"
       },
       {
         "groupId": "androidx.fragment",
         "artifactId": "fragment-ktx",
         "version": "1.8.9",
-        "nugetVersion": "1.8.9.3",
+        "nugetVersion": "1.8.9.4",
         "nugetId": "Xamarin.AndroidX.Fragment.Ktx"
       },
       {
         "groupId": "androidx.graphics",
         "artifactId": "graphics-path",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Graphics.Path"
       },
       {
         "groupId": "androidx.graphics",
         "artifactId": "graphics-shapes",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Graphics.Shapes"
       },
       {
         "groupId": "androidx.graphics",
         "artifactId": "graphics-shapes-android",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Graphics.Shapes.Android"
       },
       {
         "groupId": "androidx.gridlayout",
         "artifactId": "gridlayout",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.GridLayout"
       },
       {
         "groupId": "androidx.health.connect",
         "artifactId": "connect-client",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.Health.Connect.ConnectClient"
       },
       {
         "groupId": "androidx.health.connect",
         "artifactId": "connect-client-external-protobuf",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Health.Connect.ConnectClientExternalProtobuf"
       },
       {
         "groupId": "androidx.health.connect",
         "artifactId": "connect-client-proto",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Health.Connect.ConnectClientProto"
       },
       {
         "groupId": "androidx.heifwriter",
         "artifactId": "heifwriter",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.HeifWriter"
       },
       {
         "groupId": "androidx.interpolator",
         "artifactId": "interpolator",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Interpolator"
       },
       {
         "groupId": "androidx.leanback",
         "artifactId": "leanback",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.3",
+        "nugetVersion": "1.2.0.4",
         "nugetId": "Xamarin.AndroidX.Leanback"
       },
       {
         "groupId": "androidx.leanback",
         "artifactId": "leanback-grid",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.3",
+        "nugetVersion": "1.0.0.4",
         "nugetId": "Xamarin.AndroidX.Leanback.Grid"
       },
       {
         "groupId": "androidx.leanback",
         "artifactId": "leanback-preference",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.3",
+        "nugetVersion": "1.2.0.4",
         "nugetId": "Xamarin.AndroidX.Leanback.Preference"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-preference-v14",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Legacy.Preference.V14"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-ui",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.37",
+        "nugetVersion": "1.0.0.38",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.UI"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-core-utils",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v13",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V13"
       },
       {
         "groupId": "androidx.legacy",
         "artifactId": "legacy-support-v4",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Legacy.Support.V4"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common-java8",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Java8"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-common-jvm",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Common.Jvm"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-extensions",
         "version": "2.2.0",
-        "nugetVersion": "2.2.0.36",
+        "nugetVersion": "2.2.0.37",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-core-ktx",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-livedata-ktx",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.LiveData.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-process",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Process"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-reactivestreams",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ReactiveStreams"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-android",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-compose",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Compose"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-compose-android",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Compose.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-ktx",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-runtime-ktx-android",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Runtime.Ktx.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-service",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.Service"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-android",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-compose",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Compose"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-compose-android",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Compose.Android"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-ktx",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModel.Ktx"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState"
       },
       {
         "groupId": "androidx.lifecycle",
         "artifactId": "lifecycle-viewmodel-savedstate-android",
         "version": "2.11.0",
-        "nugetVersion": "2.11.0",
+        "nugetVersion": "2.11.0.1",
         "nugetId": "Xamarin.AndroidX.Lifecycle.ViewModelSavedState.Android"
       },
       {
         "groupId": "androidx.loader",
         "artifactId": "loader",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.36",
+        "nugetVersion": "1.1.0.37",
         "nugetId": "Xamarin.AndroidX.Loader"
       },
       {
         "groupId": "androidx.localbroadcastmanager",
         "artifactId": "localbroadcastmanager",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.24",
+        "nugetVersion": "1.1.0.25",
         "nugetId": "Xamarin.AndroidX.LocalBroadcastManager"
       },
       {
         "groupId": "androidx.media",
         "artifactId": "media",
         "version": "1.8.0",
-        "nugetVersion": "1.8.0",
+        "nugetVersion": "1.8.0.1",
         "nugetId": "Xamarin.AndroidX.Media"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-common",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.14",
+        "nugetVersion": "1.3.0.15",
         "nugetId": "Xamarin.AndroidX.Media2.Common"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-session",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.14",
+        "nugetVersion": "1.3.0.15",
         "nugetId": "Xamarin.AndroidX.Media2.Session"
       },
       {
         "groupId": "androidx.media2",
         "artifactId": "media2-widget",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.14",
+        "nugetVersion": "1.3.0.15",
         "nugetId": "Xamarin.AndroidX.Media2.Widget"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-cast",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Cast"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-common",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Common"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-container",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Container"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-database",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Database"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource-cronet",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource.CroNet"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-datasource-rtmp",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.DataSource.Rtmp"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-decoder",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Decoder"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-effect",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Effect"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-dash",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Dash"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-hls",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Hls"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-rtsp",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.Rtsp"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-smoothstreaming",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.SmoothStreaming"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-exoplayer-workmanager",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.ExoPlayer.WorkManager"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-extractor",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Extractor"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-inspector",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Inspector"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-muxer",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Muxer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-session",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1.1",
+        "nugetVersion": "1.10.1.2",
         "nugetId": "Xamarin.AndroidX.Media3.Session"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-transformer",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Transformer"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-ui",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Ui"
       },
       {
         "groupId": "androidx.media3",
         "artifactId": "media3-ui-leanback",
         "version": "1.10.1",
-        "nugetVersion": "1.10.1",
+        "nugetVersion": "1.10.1.1",
         "nugetId": "Xamarin.AndroidX.Media3.Ui.Leanback"
       },
       {
         "groupId": "androidx.mediarouter",
         "artifactId": "mediarouter",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1.3",
+        "nugetVersion": "1.8.1.4",
         "nugetId": "Xamarin.AndroidX.MediaRouter"
       },
       {
         "groupId": "androidx.multidex",
         "artifactId": "multidex",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.36",
+        "nugetVersion": "2.0.1.37",
         "nugetId": "Xamarin.AndroidX.MultiDex"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common-android",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common.Android"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-common-ktx",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Common.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-compose",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Compose"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-compose-android",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Compose.Android"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-fragment-ktx",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Fragment.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime-android",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime.Android"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-runtime-ktx",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.Runtime.Ktx"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.UI"
       },
       {
         "groupId": "androidx.navigation",
         "artifactId": "navigation-ui-ktx",
         "version": "2.9.8",
-        "nugetVersion": "2.9.8",
+        "nugetVersion": "2.9.8.1",
         "nugetId": "Xamarin.AndroidX.Navigation.UI.Ktx"
       },
       {
         "groupId": "androidx.navigationevent",
         "artifactId": "navigationevent",
         "version": "1.1.2",
-        "nugetVersion": "1.1.2",
+        "nugetVersion": "1.1.2.1",
         "nugetId": "Xamarin.AndroidX.NavigationEvent"
       },
       {
         "groupId": "androidx.navigationevent",
         "artifactId": "navigationevent-android",
         "version": "1.1.2",
-        "nugetVersion": "1.1.2",
+        "nugetVersion": "1.1.2.1",
         "nugetId": "Xamarin.AndroidX.NavigationEvent.Android"
       },
       {
         "groupId": "androidx.navigationevent",
         "artifactId": "navigationevent-compose",
         "version": "1.1.2",
-        "nugetVersion": "1.1.2",
+        "nugetVersion": "1.1.2.1",
         "nugetId": "Xamarin.AndroidX.NavigationEvent.Compose"
       },
       {
         "groupId": "androidx.navigationevent",
         "artifactId": "navigationevent-compose-android",
         "version": "1.1.2",
-        "nugetVersion": "1.1.2",
+        "nugetVersion": "1.1.2.1",
         "nugetId": "Xamarin.AndroidX.NavigationEvent.Compose.Android"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-common",
         "version": "3.5.0",
-        "nugetVersion": "3.5.0",
+        "nugetVersion": "3.5.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.Common",
         "excludedRuntimeDependencies": "androidx.paging.paging-common-android"
       },
@@ -1717,14 +1717,14 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-common-jvm",
         "version": "3.3.6",
-        "nugetVersion": "3.3.6.5",
+        "nugetVersion": "3.3.6.6",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Jvm"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-common-ktx",
         "version": "3.5.0",
-        "nugetVersion": "3.5.0",
+        "nugetVersion": "3.5.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.Common.Ktx",
         "excludedRuntimeDependencies": "androidx.paging.paging-common-desktop"
       },
@@ -1732,189 +1732,189 @@
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime",
         "version": "3.5.0",
-        "nugetVersion": "3.5.0",
+        "nugetVersion": "3.5.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-runtime-ktx",
         "version": "3.5.0",
-        "nugetVersion": "3.5.0",
+        "nugetVersion": "3.5.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.Runtime.Ktx"
       },
       {
         "groupId": "androidx.paging",
         "artifactId": "paging-rxjava2",
         "version": "3.5.0",
-        "nugetVersion": "3.5.0",
+        "nugetVersion": "3.5.0.1",
         "nugetId": "Xamarin.AndroidX.Paging.RxJava2"
       },
       {
         "groupId": "androidx.palette",
         "artifactId": "palette",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Palette"
       },
       {
         "groupId": "androidx.palette",
         "artifactId": "palette-ktx",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.29",
+        "nugetVersion": "1.0.0.30",
         "nugetId": "Xamarin.AndroidX.Palette.Palette.Ktx"
       },
       {
         "groupId": "androidx.percentlayout",
         "artifactId": "percentlayout",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.37",
+        "nugetVersion": "1.0.0.38",
         "nugetId": "Xamarin.AndroidX.PercentLayout"
       },
       {
         "groupId": "androidx.preference",
         "artifactId": "preference",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.17",
+        "nugetVersion": "1.2.1.18",
         "nugetId": "Xamarin.AndroidX.Preference"
       },
       {
         "groupId": "androidx.preference",
         "artifactId": "preference-ktx",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.17",
+        "nugetVersion": "1.2.1.18",
         "nugetId": "Xamarin.AndroidX.Preference.Preference.Ktx"
       },
       {
         "groupId": "androidx.print",
         "artifactId": "print",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.Print"
       },
       {
         "groupId": "androidx.privacysandbox.ads",
         "artifactId": "ads-adservices",
         "version": "1.1.0-beta12",
-        "nugetVersion": "1.1.0.5-beta12",
+        "nugetVersion": "1.1.0.6-beta12",
         "nugetId": "Xamarin.AndroidX.PrivacySandbox.Ads.AdsServices"
       },
       {
         "groupId": "androidx.privacysandbox.ads",
         "artifactId": "ads-adservices-java",
         "version": "1.1.0-beta12",
-        "nugetVersion": "1.1.0.5-beta12",
+        "nugetVersion": "1.1.0.6-beta12",
         "nugetId": "Xamarin.AndroidX.PrivacySandbox.Ads.AdsServices.Java"
       },
       {
         "groupId": "androidx.profileinstaller",
         "artifactId": "profileinstaller",
         "version": "1.4.1",
-        "nugetVersion": "1.4.1.7",
+        "nugetVersion": "1.4.1.8",
         "nugetId": "Xamarin.AndroidX.ProfileInstaller.ProfileInstaller"
       },
       {
         "groupId": "androidx.recommendation",
         "artifactId": "recommendation",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Recommendation"
       },
       {
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.5",
+        "nugetVersion": "1.4.0.6",
         "nugetId": "Xamarin.AndroidX.RecyclerView"
       },
       {
         "groupId": "androidx.recyclerview",
         "artifactId": "recyclerview-selection",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.3",
+        "nugetVersion": "1.2.0.4",
         "nugetId": "Xamarin.AndroidX.RecyclerView.Selection"
       },
       {
         "groupId": "androidx.resourceinspection",
         "artifactId": "resourceinspection-annotation",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.24",
+        "nugetVersion": "1.0.1.25",
         "nugetId": "Xamarin.AndroidX.ResourceInspection.Annotation"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-common",
         "version": "2.8.4",
-        "nugetVersion": "2.8.4.2",
+        "nugetVersion": "2.8.4.3",
         "nugetId": "Xamarin.AndroidX.Room.Common"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-common-jvm",
         "version": "2.8.4",
-        "nugetVersion": "2.8.4.2",
+        "nugetVersion": "2.8.4.3",
         "nugetId": "Xamarin.AndroidX.Room.Common.JVM"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-guava",
         "version": "2.8.4",
-        "nugetVersion": "2.8.4.2",
+        "nugetVersion": "2.8.4.3",
         "nugetId": "Xamarin.AndroidX.Room.Guava"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-ktx",
         "version": "2.8.4",
-        "nugetVersion": "2.8.4.2",
+        "nugetVersion": "2.8.4.3",
         "nugetId": "Xamarin.AndroidX.Room.Room.Ktx"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-runtime",
         "version": "2.8.4",
-        "nugetVersion": "2.8.4.2",
+        "nugetVersion": "2.8.4.3",
         "nugetId": "Xamarin.AndroidX.Room.Runtime"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-runtime-android",
         "version": "2.8.4",
-        "nugetVersion": "2.8.4.2",
+        "nugetVersion": "2.8.4.3",
         "nugetId": "Xamarin.AndroidX.Room.Runtime.Android"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-rxjava2",
         "version": "2.8.4",
-        "nugetVersion": "2.8.4.2",
+        "nugetVersion": "2.8.4.3",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava2"
       },
       {
         "groupId": "androidx.room",
         "artifactId": "room-rxjava3",
         "version": "2.8.4",
-        "nugetVersion": "2.8.4.2",
+        "nugetVersion": "2.8.4.3",
         "nugetId": "Xamarin.AndroidX.Room.Room.RxJava3"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.SavedState"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-android",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Android"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-compose",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Compose",
         "type": "no-bindings"
       },
@@ -1922,119 +1922,119 @@
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-compose-android",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Compose.Android"
       },
       {
         "groupId": "androidx.savedstate",
         "artifactId": "savedstate-ktx",
         "version": "1.5.0",
-        "nugetVersion": "1.5.0",
+        "nugetVersion": "1.5.0.1",
         "nugetId": "Xamarin.AndroidX.SavedState.SavedState.Ktx"
       },
       {
         "groupId": "androidx.security",
         "artifactId": "security-crypto",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Security.SecurityCrypto"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-builders",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Slice.Builders"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Slice.Core"
       },
       {
         "groupId": "androidx.slice",
         "artifactId": "slice-view",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.36",
+        "nugetVersion": "1.0.0.37",
         "nugetId": "Xamarin.AndroidX.Slice.View"
       },
       {
         "groupId": "androidx.slidingpanelayout",
         "artifactId": "slidingpanelayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.24",
+        "nugetVersion": "1.2.0.25",
         "nugetId": "Xamarin.AndroidX.SlidingPaneLayout"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Sqlite"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-android",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Sqlite.Android"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-framework",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework"
       },
       {
         "groupId": "androidx.sqlite",
         "artifactId": "sqlite-framework-android",
         "version": "2.6.2",
-        "nugetVersion": "2.6.2.2",
+        "nugetVersion": "2.6.2.3",
         "nugetId": "Xamarin.AndroidX.Sqlite.Framework.Android"
       },
       {
         "groupId": "androidx.startup",
         "artifactId": "startup-runtime",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.7",
+        "nugetVersion": "1.2.0.8",
         "nugetId": "Xamarin.AndroidX.Startup.StartupRuntime"
       },
       {
         "groupId": "androidx.swiperefreshlayout",
         "artifactId": "swiperefreshlayout",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.2",
+        "nugetVersion": "1.2.0.3",
         "nugetId": "Xamarin.AndroidX.SwipeRefreshLayout"
       },
       {
         "groupId": "androidx.tracing",
         "artifactId": "tracing",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.3",
+        "nugetVersion": "1.3.0.4",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing"
       },
       {
         "groupId": "androidx.tracing",
         "artifactId": "tracing-android",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.3",
+        "nugetVersion": "1.3.0.4",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing.Android"
       },
       {
         "groupId": "androidx.tracing",
         "artifactId": "tracing-ktx",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.3",
+        "nugetVersion": "1.3.0.4",
         "nugetId": "Xamarin.AndroidX.Tracing.Tracing.Ktx"
       },
       {
         "groupId": "androidx.transition",
         "artifactId": "transition",
         "version": "1.7.0",
-        "nugetVersion": "1.7.0.1",
+        "nugetVersion": "1.7.0.2",
         "nugetId": "Xamarin.AndroidX.Transition",
         "extraDependencies": "androidx.fragment.fragment"
       },
@@ -2042,126 +2042,126 @@
         "groupId": "androidx.tvprovider",
         "artifactId": "tvprovider",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.3",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.TvProvider"
       },
       {
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.10",
+        "nugetVersion": "1.2.0.11",
         "nugetId": "Xamarin.AndroidX.VectorDrawable"
       },
       {
         "groupId": "androidx.vectordrawable",
         "artifactId": "vectordrawable-animated",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.10",
+        "nugetVersion": "1.2.0.11",
         "nugetId": "Xamarin.AndroidX.VectorDrawable.Animated"
       },
       {
         "groupId": "androidx.versionedparcelable",
         "artifactId": "versionedparcelable",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.5",
+        "nugetVersion": "1.2.1.6",
         "nugetId": "Xamarin.AndroidX.VersionedParcelable"
       },
       {
         "groupId": "androidx.viewpager",
         "artifactId": "viewpager",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.6",
+        "nugetVersion": "1.1.0.7",
         "nugetId": "Xamarin.AndroidX.ViewPager"
       },
       {
         "groupId": "androidx.viewpager2",
         "artifactId": "viewpager2",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.10",
+        "nugetVersion": "1.1.0.11",
         "nugetId": "Xamarin.AndroidX.ViewPager2"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0.1",
+        "nugetVersion": "1.4.0.2",
         "nugetId": "Xamarin.AndroidX.Wear"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-core",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0",
+        "nugetVersion": "1.1.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.Core"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-input",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.2",
+        "nugetVersion": "1.2.0.3",
         "nugetId": "Xamarin.AndroidX.Wear.Input"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-ongoing",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.2",
+        "nugetVersion": "1.1.0.3",
         "nugetId": "Xamarin.AndroidX.Wear.Ongoing"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-phone-interactions",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.5",
+        "nugetVersion": "1.1.0.6",
         "nugetId": "Xamarin.AndroidX.Wear.PhoneInteractions"
       },
       {
         "groupId": "androidx.wear",
         "artifactId": "wear-remote-interactions",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.Wear.RemoteInteractions"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-foundation",
         "version": "1.6.2",
-        "nugetVersion": "1.6.2",
+        "nugetVersion": "1.6.2.1",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Foundation"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-material",
         "version": "1.6.2",
-        "nugetVersion": "1.6.2",
+        "nugetVersion": "1.6.2.1",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Material"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-material-core",
         "version": "1.6.2",
-        "nugetVersion": "1.6.2",
+        "nugetVersion": "1.6.2.1",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Material.Core"
       },
       {
         "groupId": "androidx.wear.compose",
         "artifactId": "compose-navigation",
         "version": "1.6.2",
-        "nugetVersion": "1.6.2",
+        "nugetVersion": "1.6.2.1",
         "nugetId": "Xamarin.AndroidX.Wear.Compose.Navigation"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-expression",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Expression",
         "excludedRuntimeDependencies": "org.jetbrains.kotlin.kotlin-stdlib",
         "extraDependencies": "org.jetbrains.kotlin.kotlin-stdlib"
@@ -2170,63 +2170,63 @@
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-expression-pipeline",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Expression.Pipeline"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-external-protobuf",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.External.Protobuf"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-material-core",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Material.Core"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-material3",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Material3"
       },
       {
         "groupId": "androidx.wear.protolayout",
         "artifactId": "protolayout-proto",
         "version": "1.4.0",
-        "nugetVersion": "1.4.0",
+        "nugetVersion": "1.4.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.ProtoLayout.Proto"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-material",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Material"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-proto",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0",
+        "nugetVersion": "1.6.0.1",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Proto"
       },
       {
         "groupId": "androidx.wear.tiles",
         "artifactId": "tiles-renderer",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.21",
+        "nugetVersion": "1.1.0.22",
         "nugetId": "Xamarin.AndroidX.Wear.Tiles.Renderer",
         "frozen": true,
         "comments": "Needs androidx.wear.protolayout.protolayout-renderer:1.1.0"
@@ -2235,182 +2235,182 @@
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-client",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Client"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-client-guava",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.ClientGuava"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.1",
+        "nugetVersion": "1.3.0.2",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.1",
+        "nugetVersion": "1.3.0.2",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-data-source",
         "version": "1.3.0",
-        "nugetVersion": "1.3.0.1",
+        "nugetVersion": "1.3.0.2",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Data.Source"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-complications-rendering",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Complications.Rendering"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-data",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Data"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-guava",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Guava"
       },
       {
         "groupId": "androidx.wear.watchface",
         "artifactId": "watchface-style",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.14",
+        "nugetVersion": "1.2.1.15",
         "nugetId": "Xamarin.AndroidX.Wear.WatchFace.Style"
       },
       {
         "groupId": "androidx.webkit",
         "artifactId": "webkit",
         "version": "1.16.0",
-        "nugetVersion": "1.16.0",
+        "nugetVersion": "1.16.0.1",
         "nugetId": "Xamarin.AndroidX.WebKit"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window",
         "version": "1.5.1",
-        "nugetVersion": "1.5.1.2",
+        "nugetVersion": "1.5.1.3",
         "nugetId": "Xamarin.AndroidX.Window"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-core",
         "version": "1.5.1",
-        "nugetVersion": "1.5.1.2",
+        "nugetVersion": "1.5.1.3",
         "nugetId": "Xamarin.AndroidX.Window.WindowCore"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-core-jvm",
         "version": "1.5.1",
-        "nugetVersion": "1.5.1.2",
+        "nugetVersion": "1.5.1.3",
         "nugetId": "Xamarin.AndroidX.Window.WindowCore.Jvm"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-extensions",
         "version": "1.0.0-alpha01",
-        "nugetVersion": "1.0.0.31-alpha01",
+        "nugetVersion": "1.0.0.32-alpha01",
         "nugetId": "Xamarin.AndroidX.Window.WindowExtensions"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-java",
         "version": "1.5.1",
-        "nugetVersion": "1.5.1.2",
+        "nugetVersion": "1.5.1.3",
         "nugetId": "Xamarin.AndroidX.Window.WindowJava"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-rxjava2",
         "version": "1.5.1",
-        "nugetVersion": "1.5.1.2",
+        "nugetVersion": "1.5.1.3",
         "nugetId": "Xamarin.AndroidX.Window.WindowRxJava2"
       },
       {
         "groupId": "androidx.window",
         "artifactId": "window-rxjava3",
         "version": "1.5.1",
-        "nugetVersion": "1.5.1.2",
+        "nugetVersion": "1.5.1.3",
         "nugetId": "Xamarin.AndroidX.Window.WindowRxJava3"
       },
       {
         "groupId": "androidx.window.extensions.core",
         "artifactId": "core",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.18",
+        "nugetVersion": "1.0.0.19",
         "nugetId": "Xamarin.AndroidX.Window.Extensions.Core.Core"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-gcm",
         "version": "2.11.2",
-        "nugetVersion": "2.11.2",
+        "nugetVersion": "2.11.2.1",
         "nugetId": "Xamarin.AndroidX.Work.GCM"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-multiprocess",
         "version": "2.11.2",
-        "nugetVersion": "2.11.2",
+        "nugetVersion": "2.11.2.1",
         "nugetId": "Xamarin.AndroidX.Work.MultiProcess"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-runtime",
         "version": "2.11.2",
-        "nugetVersion": "2.11.2",
+        "nugetVersion": "2.11.2.1",
         "nugetId": "Xamarin.AndroidX.Work.Runtime"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-runtime-ktx",
         "version": "2.11.2",
-        "nugetVersion": "2.11.2",
+        "nugetVersion": "2.11.2.1",
         "nugetId": "Xamarin.AndroidX.Work.Work.Runtime.Ktx"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-rxjava2",
         "version": "2.11.2",
-        "nugetVersion": "2.11.2",
+        "nugetVersion": "2.11.2.1",
         "nugetId": "Xamarin.AndroidX.Work.RxJava2"
       },
       {
         "groupId": "androidx.work",
         "artifactId": "work-rxjava3",
         "version": "2.11.2",
-        "nugetVersion": "2.11.2",
+        "nugetVersion": "2.11.2.1",
         "nugetId": "Xamarin.AndroidX.Work.RxJava3"
       },
       {
         "groupId": "aopalliance",
         "artifactId": "aopalliance",
         "version": "1.0",
-        "nugetVersion": "1.0.0.11",
+        "nugetVersion": "1.0.0.12",
         "nugetId": "Xamarin.AopAlliance",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2419,7 +2419,7 @@
         "groupId": "com.airbnb.android",
         "artifactId": "lottie",
         "version": "6.7.1",
-        "nugetVersion": "6.7.1.1",
+        "nugetVersion": "6.7.1.2",
         "nugetId": "Xamarin.AirBnB.Android.Lottie",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2428,7 +2428,7 @@
         "groupId": "com.android.billingclient",
         "artifactId": "billing",
         "version": "9.1.0",
-        "nugetVersion": "9.1.0",
+        "nugetVersion": "9.1.0.1",
         "nugetId": "Xamarin.Android.Google.BillingClient",
         "type": "xbd"
       },
@@ -2436,7 +2436,7 @@
         "groupId": "com.android.installreferrer",
         "artifactId": "installreferrer",
         "version": "2.2",
-        "nugetVersion": "2.2.0.7",
+        "nugetVersion": "2.2.0.8",
         "nugetId": "Xamarin.Google.Android.InstallReferrer",
         "type": "xbd"
       },
@@ -2444,7 +2444,7 @@
         "groupId": "com.android.volley",
         "artifactId": "volley",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.20",
+        "nugetVersion": "1.2.1.21",
         "nugetId": "Xamarin.Android.Volley",
         "type": "xbd"
       },
@@ -2452,7 +2452,7 @@
         "groupId": "com.android.volley",
         "artifactId": "volley-cronet",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1.20",
+        "nugetVersion": "1.2.1.21",
         "nugetId": "Xamarin.Android.Volley.CroNet",
         "type": "xbd"
       },
@@ -2460,7 +2460,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "annotations",
         "version": "5.0.7",
-        "nugetVersion": "5.0.7",
+        "nugetVersion": "5.0.7.1",
         "nugetId": "Xamarin.Android.Glide.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2469,7 +2469,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "avif-integration",
         "version": "5.0.7",
-        "nugetVersion": "5.0.7",
+        "nugetVersion": "5.0.7.1",
         "nugetId": "Xamarin.Android.Glide.AVIF.Integration",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2478,7 +2478,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "disklrucache",
         "version": "5.0.7",
-        "nugetVersion": "5.0.7",
+        "nugetVersion": "5.0.7.1",
         "nugetId": "Xamarin.Android.Glide.DiskLruCache",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2487,7 +2487,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "gifdecoder",
         "version": "5.0.7",
-        "nugetVersion": "5.0.7",
+        "nugetVersion": "5.0.7.1",
         "nugetId": "Xamarin.Android.Glide.GifDecoder",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2496,7 +2496,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "glide",
         "version": "5.0.7",
-        "nugetVersion": "5.0.7",
+        "nugetVersion": "5.0.7.1",
         "nugetId": "Xamarin.Android.Glide",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2505,7 +2505,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "recyclerview-integration",
         "version": "5.0.7",
-        "nugetVersion": "5.0.7",
+        "nugetVersion": "5.0.7.1",
         "nugetId": "Xamarin.Android.Glide.RecyclerViewIntegration",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2514,7 +2514,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-appcompat-theme",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.8",
+        "nugetVersion": "0.36.0.9",
         "nugetId": "Xamarin.Google.Accompanist.AppCompat.Theme",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2523,7 +2523,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-drawablepainter",
         "version": "0.37.3",
-        "nugetVersion": "0.37.3.3",
+        "nugetVersion": "0.37.3.4",
         "nugetId": "Xamarin.Google.Accompanist.DrawablePainter",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2532,7 +2532,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-flowlayout",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.8",
+        "nugetVersion": "0.36.0.9",
         "nugetId": "Xamarin.Google.Accompanist.FlowLayout",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2541,7 +2541,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-pager",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.8",
+        "nugetVersion": "0.36.0.9",
         "nugetId": "Xamarin.Google.Accompanist.Pager",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2550,7 +2550,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-pager-indicators",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.8",
+        "nugetVersion": "0.36.0.9",
         "nugetId": "Xamarin.Google.Accompanist.Pager.Indicators",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2559,7 +2559,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-permissions",
         "version": "0.37.3",
-        "nugetVersion": "0.37.3.3",
+        "nugetVersion": "0.37.3.4",
         "nugetId": "Xamarin.Google.Accompanist.Permissions",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2568,7 +2568,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-placeholder",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.8",
+        "nugetVersion": "0.36.0.9",
         "nugetId": "Xamarin.Google.Accompanist.Placeholder",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2577,7 +2577,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-placeholder-material",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.8",
+        "nugetVersion": "0.36.0.9",
         "nugetId": "Xamarin.Google.Accompanist.Placeholder.Material",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2586,7 +2586,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-swiperefresh",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.8",
+        "nugetVersion": "0.36.0.9",
         "nugetId": "Xamarin.Google.Accompanist.SwipeRefresh",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2595,7 +2595,7 @@
         "groupId": "com.google.accompanist",
         "artifactId": "accompanist-systemuicontroller",
         "version": "0.36.0",
-        "nugetVersion": "0.36.0.8",
+        "nugetVersion": "0.36.0.9",
         "nugetId": "Xamarin.Google.Accompanist.SystemUIController",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2604,7 +2604,7 @@
         "groupId": "com.google.ads.interactivemedia.v3",
         "artifactId": "interactivemedia",
         "version": "3.39.0",
-        "nugetVersion": "3.39.0.1",
+        "nugetVersion": "3.39.0.2",
         "nugetId": "Xamarin.Google.Ads.InteractiveMedia.V3.InteractiveMedia",
         "type": "xbd"
       },
@@ -2612,7 +2612,7 @@
         "groupId": "com.google.ai.edge.aicore",
         "artifactId": "aicore",
         "version": "0.0.1-exp02",
-        "nugetVersion": "0.0.1.2-exp02",
+        "nugetVersion": "0.0.1.3-exp02",
         "nugetId": "Xamarin.Google.AI.Edge.AICore",
         "type": "xbd"
       },
@@ -2620,7 +2620,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert",
         "version": "2.1.5",
-        "nugetVersion": "2.1.5",
+        "nugetVersion": "2.1.5.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT",
         "allowPrereleaseDependencies": true,
         "type": "androidlibrary"
@@ -2629,7 +2629,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-api",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2",
+        "nugetVersion": "1.4.2.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.API",
         "type": "androidlibrary"
       },
@@ -2637,7 +2637,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-gpu",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2",
+        "nugetVersion": "1.4.2.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.GPU",
         "type": "androidlibrary"
       },
@@ -2645,7 +2645,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-gpu-api",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2",
+        "nugetVersion": "1.4.2.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.GPU.API",
         "type": "androidlibrary"
       },
@@ -2653,7 +2653,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-metadata",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2",
+        "nugetVersion": "1.4.2.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Metadata",
         "type": "androidlibrary"
       },
@@ -2661,7 +2661,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-support",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2",
+        "nugetVersion": "1.4.2.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Support",
         "type": "androidlibrary"
       },
@@ -2669,7 +2669,7 @@
         "groupId": "com.google.ai.edge.litert",
         "artifactId": "litert-support-api",
         "version": "1.4.2",
-        "nugetVersion": "1.4.2",
+        "nugetVersion": "1.4.2.1",
         "nugetId": "Xamarin.Google.AI.Edge.LiteRT.Support.API",
         "allowPrereleaseDependencies": true,
         "type": "androidlibrary",
@@ -2679,7 +2679,7 @@
         "groupId": "com.google.ai.edge.localagents",
         "artifactId": "localagents-fc",
         "version": "0.1.0",
-        "nugetVersion": "0.1.0.2",
+        "nugetVersion": "0.1.0.3",
         "nugetId": "Xamarin.Google.AI.Edge.LocalAgents.FunctionCalling",
         "excludedRuntimeDependencies": "org.json.json",
         "type": "androidlibrary"
@@ -2688,7 +2688,7 @@
         "groupId": "com.google.ai.edge.localagents",
         "artifactId": "localagents-rag",
         "version": "0.3.0",
-        "nugetVersion": "0.3.0.2",
+        "nugetVersion": "0.3.0.3",
         "nugetId": "Xamarin.Google.AI.Edge.LocalAgents.RAG",
         "excludedRuntimeDependencies": "org.json.json",
         "type": "androidlibrary"
@@ -2697,7 +2697,7 @@
         "groupId": "com.google.android",
         "artifactId": "annotations",
         "version": "4.1.1.4",
-        "nugetVersion": "4.1.1.26",
+        "nugetVersion": "4.1.1.27",
         "nugetId": "Xamarin.Google.Android.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -2706,7 +2706,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-api",
         "version": "4.1.1",
-        "nugetVersion": "4.1.1",
+        "nugetVersion": "4.1.1.1",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportApi",
         "type": "androidlibrary"
       },
@@ -2714,7 +2714,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-backend-cct",
         "version": "4.1.1",
-        "nugetVersion": "4.1.1",
+        "nugetVersion": "4.1.1.1",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct",
         "type": "androidlibrary"
       },
@@ -2722,7 +2722,7 @@
         "groupId": "com.google.android.datatransport",
         "artifactId": "transport-runtime",
         "version": "4.1.1",
-        "nugetVersion": "4.1.1",
+        "nugetVersion": "4.1.1.1",
         "nugetId": "Xamarin.Google.Android.DataTransport.TransportRuntime",
         "type": "androidlibrary"
       },
@@ -2730,7 +2730,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads",
         "version": "25.4.0",
-        "nugetVersion": "125.4.0",
+        "nugetVersion": "125.4.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Ads",
         "allowPrereleaseDependencies": true,
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
@@ -2740,7 +2740,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-api",
         "version": "25.4.0",
-        "nugetVersion": "125.4.0",
+        "nugetVersion": "125.4.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Api",
         "type": "xbd"
       },
@@ -2748,7 +2748,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-base",
         "version": "24.1.0",
-        "nugetVersion": "124.1.0.3",
+        "nugetVersion": "124.1.0.4",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Base",
         "type": "xbd"
       },
@@ -2756,7 +2756,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-identifier",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.1",
+        "nugetVersion": "118.3.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Identifier",
         "type": "xbd"
       },
@@ -2764,7 +2764,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-lite",
         "version": "24.0.0",
-        "nugetVersion": "124.0.0.5",
+        "nugetVersion": "124.0.0.6",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Lite",
         "frozen": true,
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
@@ -2774,7 +2774,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-afs-native",
         "version": "19.1.0",
-        "nugetVersion": "119.1.0.9",
+        "nugetVersion": "119.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.AFS.Native",
         "type": "xbd"
       },
@@ -2782,7 +2782,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-analytics",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.7",
+        "nugetVersion": "118.1.1.8",
         "nugetId": "Xamarin.GooglePlayServices.Analytics",
         "type": "xbd"
       },
@@ -2790,7 +2790,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-analytics-impl",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0.7",
+        "nugetVersion": "118.2.0.8",
         "nugetId": "Xamarin.GooglePlayServices.Analytics.Impl",
         "type": "xbd"
       },
@@ -2798,7 +2798,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appindex",
         "version": "16.2.0",
-        "nugetVersion": "116.2.0.9",
+        "nugetVersion": "116.2.0.10",
         "nugetId": "Xamarin.GooglePlayServices.AppIndex",
         "type": "xbd"
       },
@@ -2806,7 +2806,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appinvite",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.25",
+        "nugetVersion": "118.0.0.26",
         "nugetId": "Xamarin.GooglePlayServices.AppInvite",
         "type": "xbd"
       },
@@ -2814,7 +2814,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-appset",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.9",
+        "nugetVersion": "116.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.AppSet",
         "type": "xbd"
       },
@@ -2822,7 +2822,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-audience",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.GooglePlayServices.Audience",
         "type": "xbd"
       },
@@ -2830,7 +2830,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth",
         "version": "21.6.0",
-        "nugetVersion": "121.6.0",
+        "nugetVersion": "121.6.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Auth",
         "type": "xbd"
       },
@@ -2838,7 +2838,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-api-phone",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.2",
+        "nugetVersion": "118.3.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Api.Phone",
         "type": "xbd"
       },
@@ -2846,7 +2846,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-base",
         "version": "18.3.3",
-        "nugetVersion": "118.3.3",
+        "nugetVersion": "118.3.3.1",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Base",
         "type": "xbd"
       },
@@ -2854,7 +2854,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-blockstore",
         "version": "16.4.0",
-        "nugetVersion": "116.4.0.8",
+        "nugetVersion": "116.4.0.9",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Blockstore",
         "type": "xbd"
       },
@@ -2862,7 +2862,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-awareness",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0",
+        "nugetVersion": "120.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Awareness",
         "type": "xbd"
       },
@@ -2870,7 +2870,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-base",
         "version": "18.10.0",
-        "nugetVersion": "118.10.0.1",
+        "nugetVersion": "118.10.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Base",
         "type": "xbd"
       },
@@ -2878,7 +2878,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-basement",
         "version": "18.10.0",
-        "nugetVersion": "118.10.0.1",
+        "nugetVersion": "118.10.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Basement",
         "type": "xbd"
       },
@@ -2886,7 +2886,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast",
         "version": "22.3.1",
-        "nugetVersion": "122.3.1",
+        "nugetVersion": "122.3.1.1",
         "nugetId": "Xamarin.GooglePlayServices.Cast",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2895,7 +2895,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast-framework",
         "version": "22.3.1",
-        "nugetVersion": "122.3.1",
+        "nugetVersion": "122.3.1.1",
         "nugetId": "Xamarin.GooglePlayServices.Cast.Framework",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -2904,7 +2904,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cast-tv",
         "version": "21.1.1",
-        "nugetVersion": "121.1.1.7",
+        "nugetVersion": "121.1.1.8",
         "nugetId": "Xamarin.GooglePlayServices.Cast.TV",
         "type": "xbd"
       },
@@ -2912,7 +2912,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-clearcut",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.GooglePlayServices.Clearcut",
         "type": "xbd"
       },
@@ -2920,7 +2920,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cloud-messaging",
         "version": "17.4.0",
-        "nugetVersion": "117.4.0",
+        "nugetVersion": "117.4.0.1",
         "nugetId": "Xamarin.GooglePlayServices.CloudMessaging",
         "type": "xbd"
       },
@@ -2928,7 +2928,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-code-scanner",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.15",
+        "nugetVersion": "116.1.0.16",
         "nugetId": "Xamarin.GooglePlayServices.Code.Scanner",
         "type": "xbd"
       },
@@ -2936,7 +2936,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cronet",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.2",
+        "nugetVersion": "118.1.1.3",
         "nugetId": "Xamarin.GooglePlayServices.CroNet",
         "type": "xbd"
       },
@@ -2944,7 +2944,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-deviceperformance",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.9",
+        "nugetVersion": "116.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.DevicePerformance",
         "type": "xbd"
       },
@@ -2952,7 +2952,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-drive",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.26",
+        "nugetVersion": "117.0.0.27",
         "nugetId": "Xamarin.GooglePlayServices.Drive",
         "type": "xbd"
       },
@@ -2960,7 +2960,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-fido",
         "version": "21.3.0",
-        "nugetVersion": "121.3.0",
+        "nugetVersion": "121.3.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Fido",
         "type": "xbd"
       },
@@ -2968,7 +2968,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-fitness",
         "version": "21.3.0",
-        "nugetVersion": "121.3.0.2",
+        "nugetVersion": "121.3.0.3",
         "nugetId": "Xamarin.GooglePlayServices.Fitness",
         "type": "xbd"
       },
@@ -2976,7 +2976,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-flags",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.9",
+        "nugetVersion": "118.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Flags",
         "type": "xbd"
       },
@@ -2984,7 +2984,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-games",
         "version": "25.0.0",
-        "nugetVersion": "125.0.0",
+        "nugetVersion": "125.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Games",
         "type": "xbd"
       },
@@ -2992,7 +2992,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-games-v2",
         "version": "21.0.0",
-        "nugetVersion": "121.0.0.3",
+        "nugetVersion": "121.0.0.4",
         "nugetId": "Xamarin.GooglePlayServices.Games.V2",
         "type": "xbd"
       },
@@ -3000,7 +3000,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-gass",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.25",
+        "nugetVersion": "120.0.0.26",
         "nugetId": "Xamarin.GooglePlayServices.Gass",
         "type": "xbd"
       },
@@ -3008,7 +3008,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-gcm",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.GooglePlayServices.Gcm",
         "type": "xbd"
       },
@@ -3016,7 +3016,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-home",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.18",
+        "nugetVersion": "116.0.0.19",
         "nugetId": "Xamarin.GooglePlayServices.Home",
         "type": "xbd"
       },
@@ -3024,7 +3024,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-identity",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.9",
+        "nugetVersion": "118.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Identity",
         "type": "xbd"
       },
@@ -3032,7 +3032,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-identity-credentials",
         "version": "16.0.0-alpha08",
-        "nugetVersion": "116.0.0-alpha08",
+        "nugetVersion": "116.0.0.1-alpha08",
         "nugetId": "Xamarin.GooglePlayServices.Identity.Credentials",
         "type": "xbd"
       },
@@ -3040,7 +3040,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-iid",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.GooglePlayServices.Iid",
         "type": "xbd"
       },
@@ -3048,7 +3048,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-instantapps",
         "version": "18.2.0",
-        "nugetVersion": "118.2.0.3",
+        "nugetVersion": "118.2.0.4",
         "nugetId": "Xamarin.GooglePlayServices.InstantApps",
         "type": "xbd"
       },
@@ -3056,7 +3056,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-location",
         "version": "21.3.0",
-        "nugetVersion": "121.3.0.9",
+        "nugetVersion": "121.3.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Location",
         "type": "xbd"
       },
@@ -3064,7 +3064,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-maps",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.1",
+        "nugetVersion": "120.0.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Maps",
         "type": "xbd"
       },
@@ -3072,7 +3072,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0",
+        "nugetVersion": "123.2.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement",
         "type": "xbd"
       },
@@ -3080,7 +3080,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-api",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0",
+        "nugetVersion": "123.2.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Api",
         "type": "xbd"
       },
@@ -3088,7 +3088,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-base",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0",
+        "nugetVersion": "123.2.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Base",
         "type": "xbd"
       },
@@ -3096,7 +3096,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-impl",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0",
+        "nugetVersion": "123.2.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Impl",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3105,7 +3105,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-sdk",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0",
+        "nugetVersion": "123.2.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Sdk",
         "type": "xbd"
       },
@@ -3113,7 +3113,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-measurement-sdk-api",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0",
+        "nugetVersion": "123.2.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Measurement.Sdk.Api",
         "type": "xbd"
       },
@@ -3121,7 +3121,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-barcode-scanning",
         "version": "18.3.1",
-        "nugetVersion": "118.3.1.7",
+        "nugetVersion": "118.3.1.8",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.BarcodeScanning",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3130,7 +3130,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-document-scanner",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.2",
+        "nugetVersion": "116.0.0.3",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.DocumentScanner",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3139,7 +3139,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-face-detection",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.18",
+        "nugetVersion": "117.1.0.19",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.FaceDetection",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3148,7 +3148,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-image-labeling",
         "version": "16.0.8",
-        "nugetVersion": "116.0.8.18",
+        "nugetVersion": "116.0.8.19",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.ImageLabeling",
         "type": "xbd"
       },
@@ -3156,7 +3156,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-language-id",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.20",
+        "nugetVersion": "117.0.0.21",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.LanguageId",
         "type": "xbd"
       },
@@ -3164,7 +3164,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition",
         "version": "19.0.1",
-        "nugetVersion": "119.0.1.7",
+        "nugetVersion": "119.0.1.8",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition",
         "type": "xbd"
       },
@@ -3172,7 +3172,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-chinese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Chinese",
         "type": "xbd"
       },
@@ -3180,7 +3180,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-common",
         "version": "19.1.0",
-        "nugetVersion": "119.1.0.7",
+        "nugetVersion": "119.1.0.8",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3189,7 +3189,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-devanagari",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Devanagari",
         "type": "xbd"
       },
@@ -3197,7 +3197,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-japanese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Japanese",
         "type": "xbd"
       },
@@ -3205,7 +3205,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-mlkit-text-recognition-korean",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.GooglePlayServices.MLKit.Text.Recognition.Korean",
         "type": "xbd"
       },
@@ -3213,7 +3213,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-nearby",
         "version": "19.3.0",
-        "nugetVersion": "119.3.0.9",
+        "nugetVersion": "119.3.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Nearby",
         "type": "xbd"
       },
@@ -3221,7 +3221,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-oss-licenses",
         "version": "17.5.1",
-        "nugetVersion": "117.5.1",
+        "nugetVersion": "117.5.1.1",
         "nugetId": "Xamarin.GooglePlayServices.Oss.Licenses",
         "excludedRuntimeDependencies": "androidx.compose.material3.material3,androidx.compose.material3.adaptive.adaptive,androidx.navigation3.navigation3-runtime,androidx.navigation3.navigation3-ui,androidx.lifecycle.lifecycle-runtime-compose,androidx.lifecycle.lifecycle-viewmodel-compose",
         "type": "xbd",
@@ -3231,7 +3231,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-pal",
         "version": "23.1.0",
-        "nugetVersion": "123.1.0.1",
+        "nugetVersion": "123.1.0.2",
         "nugetId": "Xamarin.GooglePlayServices.PAL",
         "type": "xbd"
       },
@@ -3239,7 +3239,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-panorama",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.15",
+        "nugetVersion": "117.1.0.16",
         "nugetId": "Xamarin.GooglePlayServices.Panorama",
         "type": "xbd"
       },
@@ -3247,7 +3247,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-password-complexity",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.9",
+        "nugetVersion": "118.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.PasswordComplexity",
         "type": "xbd"
       },
@@ -3255,7 +3255,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-pay",
         "version": "16.5.0",
-        "nugetVersion": "116.5.0.9",
+        "nugetVersion": "116.5.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Pay",
         "type": "xbd"
       },
@@ -3263,7 +3263,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-phenotype",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.GooglePlayServices.Phenotype",
         "type": "xbd"
       },
@@ -3271,7 +3271,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-places",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.9",
+        "nugetVersion": "117.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Places",
         "type": "xbd"
       },
@@ -3279,7 +3279,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-places-placereport",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.9",
+        "nugetVersion": "117.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Places.PlaceReport",
         "type": "xbd"
       },
@@ -3287,7 +3287,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-plus",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.26",
+        "nugetVersion": "117.0.0.27",
         "nugetId": "Xamarin.GooglePlayServices.Plus",
         "type": "xbd"
       },
@@ -3295,7 +3295,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-recaptcha",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.9",
+        "nugetVersion": "117.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Recaptcha",
         "type": "xbd"
       },
@@ -3303,7 +3303,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-recaptchabase",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.5",
+        "nugetVersion": "116.1.0.6",
         "nugetId": "Xamarin.GooglePlayServices.RecaptchaBase",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3312,7 +3312,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-safetynet",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.9",
+        "nugetVersion": "118.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.SafetyNet",
         "type": "xbd"
       },
@@ -3320,7 +3320,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-stats",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.9",
+        "nugetVersion": "117.1.0.10",
         "nugetId": "Xamarin.GooglePlayServices.Stats",
         "type": "xbd"
       },
@@ -3328,7 +3328,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-streamprotect",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.17",
+        "nugetVersion": "116.1.0.18",
         "nugetId": "Xamarin.GooglePlayServices.StreamProtect",
         "type": "xbd"
       },
@@ -3336,7 +3336,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.5",
+        "nugetVersion": "118.3.0.6",
         "nugetId": "Xamarin.GooglePlayServices.TagManager",
         "type": "xbd"
       },
@@ -3344,7 +3344,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager-api",
         "version": "18.3.0",
-        "nugetVersion": "118.3.0.5",
+        "nugetVersion": "118.3.0.6",
         "nugetId": "Xamarin.GooglePlayServices.TagManager.Api",
         "type": "xbd"
       },
@@ -3352,7 +3352,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tagmanager-v4-impl",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.7",
+        "nugetVersion": "118.1.1.8",
         "nugetId": "Xamarin.GooglePlayServices.TagManager.V4.Impl",
         "type": "xbd"
       },
@@ -3360,7 +3360,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tasks",
         "version": "18.4.1",
-        "nugetVersion": "118.4.1.1",
+        "nugetVersion": "118.4.1.2",
         "nugetId": "Xamarin.GooglePlayServices.Tasks",
         "type": "xbd"
       },
@@ -3368,7 +3368,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-gpu",
         "version": "16.5.0",
-        "nugetVersion": "116.5.0",
+        "nugetVersion": "116.5.0.1",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Gpu",
         "type": "xbd"
       },
@@ -3376,7 +3376,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-impl",
         "version": "16.5.0",
-        "nugetVersion": "116.5.0",
+        "nugetVersion": "116.5.0.1",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Impl",
         "type": "xbd"
       },
@@ -3384,7 +3384,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-java",
         "version": "16.5.0",
-        "nugetVersion": "116.5.0",
+        "nugetVersion": "116.5.0.1",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Java",
         "type": "xbd"
       },
@@ -3392,7 +3392,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-tflite-support",
         "version": "16.5.0",
-        "nugetVersion": "116.5.0",
+        "nugetVersion": "116.5.0.1",
         "nugetId": "Xamarin.GooglePlayServices.TfLite.Support",
         "type": "xbd"
       },
@@ -3400,7 +3400,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-threadnetwork",
         "version": "16.3.0",
-        "nugetVersion": "116.3.0.3",
+        "nugetVersion": "116.3.0.4",
         "nugetId": "Xamarin.GooglePlayServices.ThreadNetwork",
         "type": "xbd"
       },
@@ -3408,7 +3408,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision",
         "version": "20.1.3",
-        "nugetVersion": "120.1.3.25",
+        "nugetVersion": "120.1.3.26",
         "nugetId": "Xamarin.GooglePlayServices.Vision",
         "type": "xbd"
       },
@@ -3416,7 +3416,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-common",
         "version": "19.1.3",
-        "nugetVersion": "119.1.3.27",
+        "nugetVersion": "119.1.3.28",
         "nugetId": "Xamarin.GooglePlayServices.Vision.Common",
         "type": "xbd"
       },
@@ -3424,7 +3424,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-face-contour-internal",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.25",
+        "nugetVersion": "116.1.0.26",
         "nugetId": "Xamarin.GooglePlayServices.Vision.Face.Contour.Internal",
         "type": "xbd"
       },
@@ -3432,7 +3432,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-image-label",
         "version": "18.1.1",
-        "nugetVersion": "118.1.1.25",
+        "nugetVersion": "118.1.1.26",
         "nugetId": "Xamarin.GooglePlayServices.Vision.ImageLabel",
         "type": "xbd"
       },
@@ -3440,7 +3440,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-vision-image-labeling-internal",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.25",
+        "nugetVersion": "116.1.0.26",
         "nugetId": "Xamarin.GooglePlayServices.Vision.ImageLabelingInternal",
         "type": "xbd"
       },
@@ -3448,7 +3448,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-wallet",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0",
+        "nugetVersion": "120.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Wallet",
         "type": "xbd"
       },
@@ -3456,7 +3456,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-wearable",
         "version": "20.0.1",
-        "nugetVersion": "120.0.1",
+        "nugetVersion": "120.0.1.1",
         "nugetId": "Xamarin.GooglePlayServices.Wearable",
         "type": "xbd"
       },
@@ -3464,7 +3464,7 @@
         "groupId": "com.google.android.libraries.ads.mobile.sdk",
         "artifactId": "ads-mobile-sdk",
         "version": "1.2.1",
-        "nugetVersion": "1.2.1",
+        "nugetVersion": "1.2.1.1",
         "nugetId": "Xamarin.Google.Android.Libraries.Ads.Mobile.Sdk",
         "extraDependencies": "androidx.lifecycle.lifecycle-common-jvm,androidx.lifecycle.lifecycle-viewmodel-android,androidx.savedstate.savedstate-android,androidx.navigationevent.navigationevent-android",
         "type": "xbd"
@@ -3473,7 +3473,7 @@
         "groupId": "com.google.android.libraries.identity.googleid",
         "artifactId": "googleid",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.14",
+        "nugetVersion": "1.1.0.15",
         "nugetId": "Xamarin.Google.Android.Libraries.Identity.GoogleId",
         "frozen": true,
         "type": "xbd",
@@ -3483,7 +3483,7 @@
         "groupId": "com.google.android.libraries.places",
         "artifactId": "places",
         "version": "5.2.0",
-        "nugetVersion": "5.2.0.1",
+        "nugetVersion": "5.2.0.2",
         "nugetId": "Xamarin.Google.Android.Libraries.Places",
         "excludedRuntimeDependencies": "com.squareup.okhttp.okhttp",
         "type": "xbd"
@@ -3492,7 +3492,7 @@
         "groupId": "com.google.android.libraries.places",
         "artifactId": "places-compat",
         "version": "2.6.0",
-        "nugetVersion": "2.6.0.18",
+        "nugetVersion": "2.6.0.19",
         "nugetId": "Xamarin.Google.Android.Libraries.Places.Compat",
         "type": "xbd"
       },
@@ -3500,7 +3500,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter",
         "version": "1.1.18",
-        "nugetVersion": "1.1.18.22",
+        "nugetVersion": "1.1.18.23",
         "nugetId": "Xamarin.Google.Android.Material.Compose.Theme.Adapter",
         "frozen": true,
         "comments": "Needs com.google.android.material.compose-theme-adapter-core:1.0.1"
@@ -3509,7 +3509,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "compose-theme-adapter-3",
         "version": "1.0.18",
-        "nugetVersion": "1.0.18.21",
+        "nugetVersion": "1.0.18.22",
         "nugetId": "Xamarin.Google.Android.Material.Compose.Theme.Adapter3",
         "frozen": true,
         "comments": "Needs com.google.android.material.compose-theme-adapter-core:1.0.1"
@@ -3518,7 +3518,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.14.0",
-        "nugetVersion": "1.14.0.2",
+        "nugetVersion": "1.14.0.3",
         "nugetId": "Xamarin.Google.Android.Material",
         "comments": "Requires API-34"
       },
@@ -3526,7 +3526,7 @@
         "groupId": "com.google.android.odml",
         "artifactId": "image",
         "version": "1.0.0-beta1",
-        "nugetVersion": "1.0.0.19-beta1",
+        "nugetVersion": "1.0.0.20-beta1",
         "nugetId": "Xamarin.Google.Android.ODML.Image",
         "type": "xbd"
       },
@@ -3534,7 +3534,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "age-signals",
         "version": "0.0.3",
-        "nugetVersion": "0.0.3.1",
+        "nugetVersion": "0.0.3.2",
         "nugetId": "Xamarin.Google.Android.Play.Age.Signals",
         "type": "xbd"
       },
@@ -3542,7 +3542,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "ai-delivery",
         "version": "0.1.1-alpha01",
-        "nugetVersion": "0.1.1.2-alpha01",
+        "nugetVersion": "0.1.1.3-alpha01",
         "nugetId": "Xamarin.Google.Android.Play.AI.Delivery",
         "type": "xbd",
         "comments": "dependency of com.google.ai.edge.litert:litert:2.0.2"
@@ -3551,7 +3551,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "app-update",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.18",
+        "nugetVersion": "2.1.0.19",
         "nugetId": "Xamarin.Google.Android.Play.App.Update",
         "type": "xbd"
       },
@@ -3559,7 +3559,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "app-update-ktx",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.18",
+        "nugetVersion": "2.1.0.19",
         "nugetId": "Xamarin.Google.Android.Play.App.Update.Ktx",
         "type": "xbd"
       },
@@ -3567,7 +3567,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "asset-delivery",
         "version": "2.3.0",
-        "nugetVersion": "2.3.0.6",
+        "nugetVersion": "2.3.0.7",
         "nugetId": "Xamarin.Google.Android.Play.Asset.Delivery",
         "type": "xbd"
       },
@@ -3575,7 +3575,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core",
         "version": "1.10.3",
-        "nugetVersion": "1.10.3.21",
+        "nugetVersion": "1.10.3.22",
         "nugetId": "Xamarin.Google.Android.Play.Core",
         "type": "xbd"
       },
@@ -3583,7 +3583,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core-common",
         "version": "2.0.4",
-        "nugetVersion": "2.0.4.9",
+        "nugetVersion": "2.0.4.10",
         "nugetId": "Xamarin.Google.Android.Play.Core.Common",
         "type": "xbd"
       },
@@ -3591,7 +3591,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "core-ktx",
         "version": "1.8.1",
-        "nugetVersion": "1.8.1.18",
+        "nugetVersion": "1.8.1.19",
         "nugetId": "Xamarin.Google.Android.Play.Core.Ktx",
         "type": "xbd"
       },
@@ -3599,7 +3599,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "feature-delivery",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.17",
+        "nugetVersion": "2.1.0.18",
         "nugetId": "Xamarin.Google.Android.Play.Feature.Delivery",
         "type": "xbd"
       },
@@ -3607,7 +3607,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "hsdp",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1",
+        "nugetVersion": "2.0.1.1",
         "nugetId": "Xamarin.Google.Android.Play.Hsdp",
         "type": "xbd",
         "comments": "dependency of com.google.android.gms:play-services-ads-api:25.4.0"
@@ -3616,7 +3616,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "integrity",
         "version": "1.6.0",
-        "nugetVersion": "1.6.0.2",
+        "nugetVersion": "1.6.0.3",
         "nugetId": "Xamarin.Google.Android.Play.Integrity",
         "type": "xbd"
       },
@@ -3624,7 +3624,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "review",
         "version": "2.0.2",
-        "nugetVersion": "2.0.2.8",
+        "nugetVersion": "2.0.2.9",
         "nugetId": "Xamarin.Google.Android.Play.Review",
         "type": "xbd"
       },
@@ -3632,7 +3632,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "review-ktx",
         "version": "2.0.2",
-        "nugetVersion": "2.0.2.8",
+        "nugetVersion": "2.0.2.9",
         "nugetId": "Xamarin.Google.Android.Play.Review.Ktx",
         "type": "xbd"
       },
@@ -3640,7 +3640,7 @@
         "groupId": "com.google.android.recaptcha",
         "artifactId": "recaptcha",
         "version": "18.9.1",
-        "nugetVersion": "18.9.1",
+        "nugetVersion": "18.9.1.1",
         "nugetId": "Xamarin.Google.Android.Recaptcha",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -3649,7 +3649,7 @@
         "groupId": "com.google.android.tv",
         "artifactId": "tv-ads",
         "version": "1.0.1",
-        "nugetVersion": "1.0.1.7",
+        "nugetVersion": "1.0.1.8",
         "nugetId": "Xamarin.Google.Android.TV.Ads",
         "type": "xbd"
       },
@@ -3657,7 +3657,7 @@
         "groupId": "com.google.android.ump",
         "artifactId": "user-messaging-platform",
         "version": "4.0.0",
-        "nugetVersion": "4.0.0.2",
+        "nugetVersion": "4.0.0.3",
         "nugetId": "Xamarin.Google.UserMessagingPlatform",
         "type": "xbd"
       },
@@ -3665,14 +3665,14 @@
         "groupId": "com.google.assistant.appactions",
         "artifactId": "suggestions",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.22",
+        "nugetVersion": "1.0.0.23",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Suggestions"
       },
       {
         "groupId": "com.google.assistant.appactions",
         "artifactId": "widgets",
         "version": "0.0.1",
-        "nugetVersion": "0.0.1.23",
+        "nugetVersion": "0.0.1.24",
         "nugetId": "Xamarin.Google.Assistant.AppActions.Widgets",
         "type": "xbd"
       },
@@ -3680,7 +3680,7 @@
         "groupId": "com.google.auto.value",
         "artifactId": "auto-value",
         "version": "1.8.2",
-        "nugetVersion": "1.8.2.2",
+        "nugetVersion": "1.8.2.3",
         "nugetId": "Xamarin.Google.AutoValue",
         "frozen": true,
         "type": "androidlibrary",
@@ -3691,7 +3691,7 @@
         "groupId": "com.google.auto.value",
         "artifactId": "auto-value-annotations",
         "version": "1.11.1",
-        "nugetVersion": "1.11.1.2",
+        "nugetVersion": "1.11.1.3",
         "nugetId": "Xamarin.Google.AutoValue.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3700,7 +3700,7 @@
         "groupId": "com.google.code.findbugs",
         "artifactId": "jsr305",
         "version": "3.0.2",
-        "nugetVersion": "3.0.2.23",
+        "nugetVersion": "3.0.2.24",
         "nugetId": "Xamarin.Google.Code.FindBugs.JSR305",
         "assemblyName": "Jsr305Binding",
         "type": "androidlibrary",
@@ -3710,7 +3710,7 @@
         "groupId": "com.google.code.gson",
         "artifactId": "gson",
         "version": "2.14.0",
-        "nugetVersion": "2.14.0",
+        "nugetVersion": "2.14.0.1",
         "nugetId": "GoogleGson",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3719,7 +3719,7 @@
         "groupId": "com.google.crypto.tink",
         "artifactId": "tink-android",
         "version": "1.22.0",
-        "nugetVersion": "1.22.0",
+        "nugetVersion": "1.22.0.1",
         "nugetId": "Xamarin.Google.Crypto.Tink.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3728,7 +3728,7 @@
         "groupId": "com.google.dagger",
         "artifactId": "dagger",
         "version": "2.59.2",
-        "nugetVersion": "2.59.2.1",
+        "nugetVersion": "2.59.2.2",
         "nugetId": "Xamarin.Google.Dagger",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3737,7 +3737,7 @@
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
         "version": "2.50.0",
-        "nugetVersion": "2.50.0",
+        "nugetVersion": "2.50.0.1",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3746,7 +3746,7 @@
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_type_annotations",
         "version": "2.50.0",
-        "nugetVersion": "2.50.0",
+        "nugetVersion": "2.50.0.1",
         "nugetId": "Xamarin.Google.ErrorProne.TypeAnnotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -3755,7 +3755,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-abt",
         "version": "23.0.1",
-        "nugetVersion": "123.0.1.2",
+        "nugetVersion": "123.0.1.3",
         "nugetId": "Xamarin.Firebase.Abt",
         "type": "xbd"
       },
@@ -3763,7 +3763,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ads",
         "version": "23.6.0",
-        "nugetVersion": "123.6.0.6",
+        "nugetVersion": "123.6.0.7",
         "nugetId": "Xamarin.Firebase.Ads",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core",
         "type": "xbd"
@@ -3772,7 +3772,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics",
         "version": "23.2.0",
-        "nugetVersion": "123.2.0",
+        "nugetVersion": "123.2.0.1",
         "nugetId": "Xamarin.Firebase.Analytics",
         "type": "xbd"
       },
@@ -3780,7 +3780,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics-impl",
         "version": "16.3.0",
-        "nugetVersion": "116.3.0.25",
+        "nugetVersion": "116.3.0.26",
         "nugetId": "Xamarin.Firebase.Analytics.Impl",
         "type": "xbd"
       },
@@ -3788,7 +3788,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-annotations",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.3",
+        "nugetVersion": "117.0.0.4",
         "nugetId": "Xamarin.Firebase.Annotations",
         "type": "xbd"
       },
@@ -3796,7 +3796,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck",
         "version": "19.2.0",
-        "nugetVersion": "119.2.0",
+        "nugetVersion": "119.2.0.1",
         "nugetId": "Xamarin.Firebase.AppCheck",
         "type": "xbd"
       },
@@ -3804,7 +3804,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-interop",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.13",
+        "nugetVersion": "117.1.0.14",
         "nugetId": "Xamarin.Firebase.AppCheck.Interop",
         "type": "xbd"
       },
@@ -3812,7 +3812,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appcheck-playintegrity",
         "version": "19.2.0",
-        "nugetVersion": "119.2.0",
+        "nugetVersion": "119.2.0.1",
         "nugetId": "Xamarin.Firebase.AppCheck.PlayIntegrity",
         "type": "xbd"
       },
@@ -3820,7 +3820,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appindexing",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.28",
+        "nugetVersion": "120.0.0.29",
         "nugetId": "Xamarin.Firebase.AppIndexing",
         "type": "xbd"
       },
@@ -3828,7 +3828,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-auth",
         "version": "24.1.0",
-        "nugetVersion": "124.1.0",
+        "nugetVersion": "124.1.0.1",
         "nugetId": "Xamarin.Firebase.Auth",
         "type": "xbd"
       },
@@ -3836,7 +3836,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-auth-interop",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.25",
+        "nugetVersion": "120.0.0.26",
         "nugetId": "Xamarin.Firebase.Auth.Interop",
         "type": "xbd"
       },
@@ -3844,7 +3844,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-common",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0",
+        "nugetVersion": "122.1.0.1",
         "nugetId": "Xamarin.Firebase.Common",
         "type": "xbd"
       },
@@ -3852,7 +3852,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-common-ktx",
         "version": "21.0.0",
-        "nugetVersion": "121.0.0.9",
+        "nugetVersion": "121.0.0.10",
         "nugetId": "Xamarin.Firebase.Common.Ktx",
         "type": "xbd"
       },
@@ -3860,7 +3860,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-components",
         "version": "19.0.1",
-        "nugetVersion": "119.0.1.1",
+        "nugetVersion": "119.0.1.2",
         "nugetId": "Xamarin.Firebase.Components",
         "type": "xbd"
       },
@@ -3868,7 +3868,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-config",
         "version": "23.1.0",
-        "nugetVersion": "123.1.0",
+        "nugetVersion": "123.1.0.1",
         "nugetId": "Xamarin.Firebase.Config",
         "type": "xbd"
       },
@@ -3876,7 +3876,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-config-interop",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.11",
+        "nugetVersion": "116.0.1.12",
         "nugetId": "Xamarin.Firebase.Config.Interop",
         "type": "xbd"
       },
@@ -3884,7 +3884,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-core",
         "version": "21.1.1",
-        "nugetVersion": "121.1.1.18",
+        "nugetVersion": "121.1.1.19",
         "nugetId": "Xamarin.Firebase.Core",
         "type": "xbd"
       },
@@ -3892,7 +3892,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crash",
         "version": "16.2.1",
-        "nugetVersion": "116.2.1.25",
+        "nugetVersion": "116.2.1.26",
         "nugetId": "Xamarin.Firebase.Crash",
         "type": "xbd"
       },
@@ -3900,7 +3900,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crashlytics",
         "version": "20.0.6",
-        "nugetVersion": "120.0.6",
+        "nugetVersion": "120.0.6.1",
         "nugetId": "Xamarin.Firebase.Crashlytics",
         "extraDependencies": "com.google.dagger.dagger",
         "type": "xbd"
@@ -3909,7 +3909,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-crashlytics-ndk",
         "version": "20.0.6",
-        "nugetVersion": "120.0.6",
+        "nugetVersion": "120.0.6.1",
         "nugetId": "Xamarin.Firebase.Crashlytics.NDK",
         "type": "xbd"
       },
@@ -3917,7 +3917,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database",
         "version": "22.0.1",
-        "nugetVersion": "122.0.1.2",
+        "nugetVersion": "122.0.1.3",
         "nugetId": "Xamarin.Firebase.Database",
         "type": "xbd"
       },
@@ -3925,7 +3925,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database-collection",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.18",
+        "nugetVersion": "118.0.1.19",
         "nugetId": "Xamarin.Firebase.Database.Collection",
         "type": "xbd"
       },
@@ -3933,7 +3933,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-database-connection",
         "version": "16.0.2",
-        "nugetVersion": "116.0.2.25",
+        "nugetVersion": "116.0.2.26",
         "nugetId": "Xamarin.Firebase.Database.Connection",
         "type": "xbd"
       },
@@ -3941,7 +3941,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-datatransport",
         "version": "20.0.1",
-        "nugetVersion": "120.0.1.2",
+        "nugetVersion": "120.0.1.3",
         "nugetId": "Xamarin.Firebase.Datatransport",
         "type": "xbd"
       },
@@ -3949,7 +3949,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-dynamic-links",
         "version": "22.1.0",
-        "nugetVersion": "122.1.0.9",
+        "nugetVersion": "122.1.0.10",
         "nugetId": "Xamarin.Firebase.Dynamic.Links",
         "type": "xbd"
       },
@@ -3957,7 +3957,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.Firebase.Encoders",
         "type": "xbd"
       },
@@ -3965,7 +3965,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders-json",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.17",
+        "nugetVersion": "118.0.1.18",
         "nugetId": "Xamarin.Firebase.Encoders.JSON",
         "type": "xbd"
       },
@@ -3973,7 +3973,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-encoders-proto",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.20",
+        "nugetVersion": "116.0.0.21",
         "nugetId": "Xamarin.Firebase.Encoders.Proto",
         "type": "xbd"
       },
@@ -3981,7 +3981,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-firestore",
         "version": "26.0.2",
-        "nugetVersion": "126.0.2.2",
+        "nugetVersion": "126.0.2.3",
         "nugetId": "Xamarin.Firebase.Firestore",
         "frozen": true,
         "extraDependencies": "com.google.guava.guava",
@@ -3993,7 +3993,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-functions",
         "version": "22.1.1",
-        "nugetVersion": "122.1.1",
+        "nugetVersion": "122.1.1.1",
         "nugetId": "Xamarin.Firebase.Functions",
         "type": "xbd"
       },
@@ -4001,7 +4001,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-iid",
         "version": "21.1.0",
-        "nugetVersion": "121.1.0.25",
+        "nugetVersion": "121.1.0.26",
         "nugetId": "Xamarin.Firebase.Iid",
         "type": "xbd"
       },
@@ -4009,7 +4009,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-iid-interop",
         "version": "17.1.0",
-        "nugetVersion": "117.1.0.25",
+        "nugetVersion": "117.1.0.26",
         "nugetId": "Xamarin.Firebase.Iid.Interop",
         "type": "xbd"
       },
@@ -4017,7 +4017,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-inappmessaging",
         "version": "22.0.3",
-        "nugetVersion": "122.0.3",
+        "nugetVersion": "122.0.3.1",
         "nugetId": "Xamarin.Firebase.InAppMessaging",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -4027,7 +4027,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-inappmessaging-display",
         "version": "22.0.3",
-        "nugetVersion": "122.0.3",
+        "nugetVersion": "122.0.3.1",
         "nugetId": "Xamarin.Firebase.InAppMessaging.Display",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -4037,7 +4037,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-installations",
         "version": "19.1.1",
-        "nugetVersion": "119.1.1",
+        "nugetVersion": "119.1.1.1",
         "nugetId": "Xamarin.Firebase.Installations",
         "type": "xbd"
       },
@@ -4045,7 +4045,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-installations-interop",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.1",
+        "nugetVersion": "117.3.0.2",
         "nugetId": "Xamarin.Firebase.Installations.InterOp",
         "type": "xbd"
       },
@@ -4053,7 +4053,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-invites",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.Firebase.Invites",
         "type": "xbd"
       },
@@ -4061,7 +4061,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-measurement-connector",
         "version": "20.0.1",
-        "nugetVersion": "120.0.1.13",
+        "nugetVersion": "120.0.1.14",
         "nugetId": "Xamarin.Firebase.Measurement.Connector",
         "type": "xbd"
       },
@@ -4069,7 +4069,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-messaging",
         "version": "25.1.0",
-        "nugetVersion": "125.1.0",
+        "nugetVersion": "125.1.0.1",
         "nugetId": "Xamarin.Firebase.Messaging",
         "type": "xbd"
       },
@@ -4077,7 +4077,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-common",
         "version": "22.1.2",
-        "nugetVersion": "122.1.2.25",
+        "nugetVersion": "122.1.2.26",
         "nugetId": "Xamarin.Firebase.ML.Common",
         "type": "xbd"
       },
@@ -4085,7 +4085,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-model-interpreter",
         "version": "22.0.4",
-        "nugetVersion": "122.0.4.25",
+        "nugetVersion": "122.0.4.26",
         "nugetId": "Xamarin.Firebase.ML.Model.Interpreter",
         "type": "xbd"
       },
@@ -4093,7 +4093,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language",
         "version": "22.0.1",
-        "nugetVersion": "122.0.1.25",
+        "nugetVersion": "122.0.1.26",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language",
         "type": "xbd"
       },
@@ -4101,7 +4101,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-language-id-model",
         "version": "20.0.8",
-        "nugetVersion": "120.0.8.25",
+        "nugetVersion": "120.0.8.26",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Id.Model",
         "type": "xbd"
       },
@@ -4109,7 +4109,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-smart-reply",
         "version": "18.0.8",
-        "nugetVersion": "118.0.8.25",
+        "nugetVersion": "118.0.8.26",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Smart.Reply",
         "type": "xbd"
       },
@@ -4117,7 +4117,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-smart-reply-model",
         "version": "20.0.8",
-        "nugetVersion": "120.0.8.25",
+        "nugetVersion": "120.0.8.26",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Smart.Reply.Model",
         "type": "xbd"
       },
@@ -4125,7 +4125,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-translate",
         "version": "22.0.2",
-        "nugetVersion": "122.0.2.24",
+        "nugetVersion": "122.0.2.25",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Translate",
         "type": "xbd"
       },
@@ -4133,7 +4133,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-natural-language-translate-model",
         "version": "20.0.9",
-        "nugetVersion": "120.0.9.25",
+        "nugetVersion": "120.0.9.26",
         "nugetId": "Xamarin.Firebase.ML.Natural.Language.Translate.Model",
         "type": "xbd"
       },
@@ -4141,7 +4141,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision",
         "version": "24.1.0",
-        "nugetVersion": "124.1.0.25",
+        "nugetVersion": "124.1.0.26",
         "nugetId": "Xamarin.Firebase.ML.Vision",
         "type": "xbd"
       },
@@ -4149,7 +4149,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-automl",
         "version": "18.0.6",
-        "nugetVersion": "118.0.6.25",
+        "nugetVersion": "118.0.6.26",
         "nugetId": "Xamarin.Firebase.ML.Vision.AutoML",
         "type": "xbd"
       },
@@ -4157,7 +4157,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-barcode-model",
         "version": "16.1.2",
-        "nugetVersion": "116.1.2.25",
+        "nugetVersion": "116.1.2.26",
         "nugetId": "Xamarin.Firebase.ML.Vision.BarCode.Model",
         "type": "xbd"
       },
@@ -4165,7 +4165,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-face-model",
         "version": "20.0.2",
-        "nugetVersion": "120.0.2.25",
+        "nugetVersion": "120.0.2.26",
         "nugetId": "Xamarin.Firebase.ML.Vision.Face.Model",
         "type": "xbd"
       },
@@ -4173,7 +4173,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-image-label-model",
         "version": "20.0.2",
-        "nugetVersion": "120.0.2.25",
+        "nugetVersion": "120.0.2.26",
         "nugetId": "Xamarin.Firebase.ML.Vision.Image.Label.Model",
         "type": "xbd"
       },
@@ -4181,7 +4181,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-internal-vkp",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.25",
+        "nugetVersion": "117.0.2.26",
         "nugetId": "Xamarin.Firebase.ML.Vision.Internal.Vkp",
         "type": "xbd"
       },
@@ -4189,7 +4189,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ml-vision-object-detection-model",
         "version": "19.0.6",
-        "nugetVersion": "119.0.6.25",
+        "nugetVersion": "119.0.6.26",
         "nugetId": "Xamarin.Firebase.ML.Vision.Object.Detection.Model",
         "type": "xbd"
       },
@@ -4197,7 +4197,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-perf",
         "version": "22.0.5",
-        "nugetVersion": "122.0.5",
+        "nugetVersion": "122.0.5.1",
         "nugetId": "Xamarin.Firebase.Perf",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -4207,7 +4207,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-sessions",
         "version": "3.0.6",
-        "nugetVersion": "103.0.6",
+        "nugetVersion": "103.0.6.1",
         "nugetId": "Xamarin.Firebase.Sessions",
         "type": "xbd"
       },
@@ -4215,7 +4215,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-storage",
         "version": "22.0.1",
-        "nugetVersion": "122.0.1.2",
+        "nugetVersion": "122.0.1.3",
         "nugetId": "Xamarin.Firebase.Storage",
         "type": "xbd"
       },
@@ -4223,7 +4223,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-storage-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.Firebase.Storage.Common",
         "type": "xbd"
       },
@@ -4231,7 +4231,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "protolite-well-known-types",
         "version": "18.0.1",
-        "nugetVersion": "118.0.1.5",
+        "nugetVersion": "118.0.1.6",
         "nugetId": "Xamarin.Firebase.ProtoliteWellKnownTypes",
         "type": "xbd",
         "skipExtendedTests": true,
@@ -4241,7 +4241,7 @@
         "groupId": "com.google.flatbuffers",
         "artifactId": "flatbuffers-java",
         "version": "25.2.10",
-        "nugetVersion": "25.2.10.5",
+        "nugetVersion": "25.2.10.6",
         "nugetId": "Xamarin.Google.FlatBuffers.Java",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4250,7 +4250,7 @@
         "groupId": "com.google.flogger",
         "artifactId": "flogger",
         "version": "0.9",
-        "nugetVersion": "0.9.0.3",
+        "nugetVersion": "0.9.0.4",
         "nugetId": "Xamarin.Flogger",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4259,7 +4259,7 @@
         "groupId": "com.google.flogger",
         "artifactId": "flogger-system-backend",
         "version": "0.9",
-        "nugetVersion": "0.9.0.3",
+        "nugetVersion": "0.9.0.4",
         "nugetId": "Xamarin.Flogger.SystemBackend",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4268,7 +4268,7 @@
         "groupId": "com.google.guava",
         "artifactId": "failureaccess",
         "version": "1.0.3",
-        "nugetVersion": "1.0.3.5",
+        "nugetVersion": "1.0.3.6",
         "nugetId": "Xamarin.Google.Guava.FailureAccess",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4277,7 +4277,7 @@
         "groupId": "com.google.guava",
         "artifactId": "guava",
         "version": "33.6.0-android",
-        "nugetVersion": "33.6.0",
+        "nugetVersion": "33.6.0.1",
         "nugetId": "Xamarin.Google.Guava",
         "excludedRuntimeDependencies": "com.google.guava.listenablefuture",
         "type": "androidlibrary",
@@ -4287,7 +4287,7 @@
         "groupId": "com.google.guava",
         "artifactId": "listenablefuture",
         "version": "1.0",
-        "nugetVersion": "1.0.0.31",
+        "nugetVersion": "1.0.0.32",
         "nugetId": "Xamarin.Google.Guava.ListenableFuture",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4296,7 +4296,7 @@
         "groupId": "com.google.inject",
         "artifactId": "guice",
         "version": "7.0.0",
-        "nugetVersion": "7.0.0.9",
+        "nugetVersion": "7.0.0.10",
         "nugetId": "Xamarin.Google.Inject.Guice",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4305,7 +4305,7 @@
         "groupId": "com.google.j2objc",
         "artifactId": "j2objc-annotations",
         "version": "3.1",
-        "nugetVersion": "3.1.0.2",
+        "nugetVersion": "3.1.0.3",
         "nugetId": "Xamarin.Google.J2Objc.Annotations",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -4314,7 +4314,7 @@
         "groupId": "com.google.mediapipe",
         "artifactId": "tasks-genai",
         "version": "0.10.35",
-        "nugetVersion": "0.10.35",
+        "nugetVersion": "0.10.35.1",
         "nugetId": "Xamarin.Google.MediaPipe.Tasks.GenAI",
         "type": "androidlibrary"
       },
@@ -4322,7 +4322,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "barcode-scanning",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.7",
+        "nugetVersion": "117.3.0.8",
         "nugetId": "Xamarin.Google.MLKit.BarcodeScanning",
         "type": "xbd"
       },
@@ -4330,7 +4330,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "barcode-scanning-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.20",
+        "nugetVersion": "117.0.0.21",
         "nugetId": "Xamarin.Google.MLKit.BarcodeScanning.Common",
         "type": "xbd"
       },
@@ -4338,7 +4338,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "common",
         "version": "18.11.0",
-        "nugetVersion": "118.11.0.7",
+        "nugetVersion": "118.11.0.8",
         "nugetId": "Xamarin.Google.MLKit.Common",
         "type": "xbd"
       },
@@ -4346,7 +4346,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "digital-ink-common",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.2",
+        "nugetVersion": "116.0.0.3",
         "nugetId": "Xamarin.Google.MLKit.DigitalInk.Common",
         "type": "xbd"
       },
@@ -4354,7 +4354,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "digital-ink-recognition",
         "version": "19.0.0",
-        "nugetVersion": "119.0.0.2",
+        "nugetVersion": "119.0.0.3",
         "nugetId": "Xamarin.Google.MLKit.DigitalInk.Recognition",
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
         "type": "xbd"
@@ -4363,7 +4363,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "face-detection",
         "version": "16.1.7",
-        "nugetVersion": "116.1.7.7",
+        "nugetVersion": "116.1.7.8",
         "nugetId": "Xamarin.Google.MLKit.FaceDetection",
         "type": "xbd"
       },
@@ -4371,7 +4371,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "genai-common",
         "version": "1.0.0-beta2",
-        "nugetVersion": "1.0.0.2-beta2",
+        "nugetVersion": "1.0.0.3-beta2",
         "nugetId": "Xamarin.Google.MLKit.GenAI.Common",
         "type": "xbd"
       },
@@ -4379,7 +4379,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "genai-prompt",
         "version": "1.0.0-alpha1",
-        "nugetVersion": "1.0.0.2-alpha1",
+        "nugetVersion": "1.0.0.3-alpha1",
         "nugetId": "Xamarin.Google.MLKit.GenAI.Prompt",
         "type": "xbd"
       },
@@ -4387,7 +4387,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling",
         "version": "17.0.9",
-        "nugetVersion": "117.0.9.7",
+        "nugetVersion": "117.0.9.8",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling",
         "type": "xbd"
       },
@@ -4395,7 +4395,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-automl",
         "version": "16.2.1",
-        "nugetVersion": "116.2.1.26",
+        "nugetVersion": "116.2.1.27",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.AutoML",
         "type": "xbd"
       },
@@ -4403,7 +4403,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-common",
         "version": "18.1.0",
-        "nugetVersion": "118.1.0.18",
+        "nugetVersion": "118.1.0.19",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4412,7 +4412,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-custom",
         "version": "17.0.3",
-        "nugetVersion": "117.0.3.7",
+        "nugetVersion": "117.0.3.8",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Custom",
         "type": "xbd"
       },
@@ -4420,7 +4420,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-custom-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.20",
+        "nugetVersion": "117.0.0.21",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Custom.Common",
         "type": "xbd"
       },
@@ -4428,7 +4428,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-default-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.20",
+        "nugetVersion": "117.0.0.21",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Default.Common",
         "type": "xbd"
       },
@@ -4436,7 +4436,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "language-id",
         "version": "17.0.6",
-        "nugetVersion": "117.0.6.7",
+        "nugetVersion": "117.0.6.8",
         "nugetId": "Xamarin.Google.MLKit.Language.Id",
         "type": "xbd"
       },
@@ -4444,7 +4444,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "language-id-common",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.18",
+        "nugetVersion": "116.1.0.19",
         "nugetId": "Xamarin.Google.MLKit.Language.Id.Common",
         "type": "xbd"
       },
@@ -4452,7 +4452,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "linkfirebase",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.20",
+        "nugetVersion": "117.0.0.21",
         "nugetId": "Xamarin.Google.MLKit.LinkFirebase",
         "type": "xbd"
       },
@@ -4460,7 +4460,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "mediapipe-internal",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0.25",
+        "nugetVersion": "116.0.0.26",
         "nugetId": "Xamarin.Google.MLKit.MediaPipe.Internal",
         "type": "xbd"
       },
@@ -4468,7 +4468,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.7",
+        "nugetVersion": "117.0.2.8",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection",
         "type": "xbd"
       },
@@ -4476,7 +4476,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection-common",
         "version": "18.0.0",
-        "nugetVersion": "118.0.0.21",
+        "nugetVersion": "118.0.0.22",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4485,7 +4485,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "object-detection-custom",
         "version": "17.0.2",
-        "nugetVersion": "117.0.2.7",
+        "nugetVersion": "117.0.2.8",
         "nugetId": "Xamarin.Google.MLKit.ObjectDetection.Custom",
         "type": "xbd"
       },
@@ -4493,7 +4493,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection",
         "type": "xbd"
       },
@@ -4501,7 +4501,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection-accurate",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection.Accurate",
         "type": "xbd"
       },
@@ -4509,7 +4509,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "pose-detection-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.25",
+        "nugetVersion": "117.0.0.26",
         "nugetId": "Xamarin.Google.MLKit.PoseDetection.Common",
         "type": "xbd"
       },
@@ -4517,7 +4517,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "smart-reply",
         "version": "17.0.4",
-        "nugetVersion": "117.0.4.7",
+        "nugetVersion": "117.0.4.8",
         "nugetId": "Xamarin.Google.MLKit.SmartReply",
         "type": "xbd"
       },
@@ -4525,7 +4525,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "smart-reply-common",
         "version": "16.1.0",
-        "nugetVersion": "116.1.0.18",
+        "nugetVersion": "116.1.0.19",
         "nugetId": "Xamarin.Google.MLKit.SmartReply.Common",
         "type": "xbd"
       },
@@ -4533,7 +4533,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition",
         "type": "xbd"
       },
@@ -4541,7 +4541,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-bundled-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0.7",
+        "nugetVersion": "117.0.0.8",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Bundled.Common",
         "type": "xbd"
       },
@@ -4549,7 +4549,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-chinese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Chinese",
         "type": "xbd"
       },
@@ -4557,7 +4557,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-devanagari",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Devanagari",
         "type": "xbd"
       },
@@ -4565,7 +4565,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-japanese",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Japanese",
         "type": "xbd"
       },
@@ -4573,7 +4573,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "text-recognition-korean",
         "version": "16.0.1",
-        "nugetVersion": "116.0.1.7",
+        "nugetVersion": "116.0.1.8",
         "nugetId": "Xamarin.Google.MLKit.TextRecognition.Korean",
         "type": "xbd"
       },
@@ -4581,7 +4581,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "translate",
         "version": "17.0.3",
-        "nugetVersion": "117.0.3.7",
+        "nugetVersion": "117.0.3.8",
         "nugetId": "Xamarin.Google.MLKit.Translate",
         "type": "xbd"
       },
@@ -4589,7 +4589,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-common",
         "version": "17.3.0",
-        "nugetVersion": "117.3.0.18",
+        "nugetVersion": "117.3.0.19",
         "nugetId": "Xamarin.Google.MLKit.Vision.Common",
         "allowPrereleaseDependencies": true,
         "type": "xbd"
@@ -4598,7 +4598,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-interfaces",
         "version": "16.3.0",
-        "nugetVersion": "116.3.0.12",
+        "nugetVersion": "116.3.0.13",
         "nugetId": "Xamarin.Google.MLKit.Vision.Interfaces",
         "type": "xbd"
       },
@@ -4606,7 +4606,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "vision-internal-vkp",
         "version": "18.2.3",
-        "nugetVersion": "118.2.3.7",
+        "nugetVersion": "118.2.3.8",
         "nugetId": "Xamarin.Google.MLKit.Vision.Internal.Vkp",
         "type": "xbd"
       },
@@ -4614,7 +4614,7 @@
         "groupId": "com.google.protobuf",
         "artifactId": "protobuf-javalite",
         "version": "4.35.1",
-        "nugetVersion": "4.35.1",
+        "nugetVersion": "4.35.1.1",
         "nugetId": "Xamarin.Protobuf.JavaLite",
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
         "type": "androidlibrary",
@@ -4624,7 +4624,7 @@
         "groupId": "com.google.protobuf",
         "artifactId": "protobuf-lite",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.23",
+        "nugetVersion": "3.0.1.24",
         "nugetId": "Xamarin.Protobuf.Lite",
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
         "type": "androidlibrary",
@@ -4634,7 +4634,7 @@
         "groupId": "com.google.zxing",
         "artifactId": "core",
         "version": "3.5.4",
-        "nugetVersion": "3.5.4.2",
+        "nugetVersion": "3.5.4.3",
         "nugetId": "Xamarin.Google.ZXing.Core",
         "assemblyName": "Google.ZXing.Core",
         "type": "androidlibrary",
@@ -4644,7 +4644,7 @@
         "groupId": "com.squareup",
         "artifactId": "javapoet",
         "version": "1.13.0",
-        "nugetVersion": "1.13.0.19",
+        "nugetVersion": "1.13.0.20",
         "nugetId": "Square.JavaPoet",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4653,7 +4653,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "logging-interceptor",
         "version": "5.4.0",
-        "nugetVersion": "5.4.0",
+        "nugetVersion": "5.4.0.1",
         "nugetId": "Square.OkHttp3.LoggingInterceptor",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4662,7 +4662,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp",
         "version": "5.4.0",
-        "nugetVersion": "5.4.0",
+        "nugetVersion": "5.4.0.1",
         "nugetId": "Square.OkHttp3",
         "extraDependencies": "com.squareup.okhttp3.okhttp-android",
         "type": "androidlibrary",
@@ -4672,7 +4672,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-android",
         "version": "5.4.0",
-        "nugetVersion": "5.4.0",
+        "nugetVersion": "5.4.0.1",
         "nugetId": "Square.OkHttp3.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4681,7 +4681,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-brotli",
         "version": "5.4.0",
-        "nugetVersion": "5.4.0",
+        "nugetVersion": "5.4.0.1",
         "nugetId": "Square.OkHttp3.OkHttp.Brotli",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4690,7 +4690,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-java-net-cookiejar",
         "version": "5.4.0",
-        "nugetVersion": "5.4.0",
+        "nugetVersion": "5.4.0.1",
         "nugetId": "Square.OkHttp3.JavaNetCookieJar",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4699,7 +4699,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-jvm",
         "version": "5.4.0",
-        "nugetVersion": "5.4.0",
+        "nugetVersion": "5.4.0.1",
         "nugetId": "Square.OkHttp3.JVM",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4708,7 +4708,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-tls",
         "version": "5.4.0",
-        "nugetVersion": "5.4.0",
+        "nugetVersion": "5.4.0.1",
         "nugetId": "Square.OkHttp3.OkHttp.TLS",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4717,7 +4717,7 @@
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-urlconnection",
         "version": "5.4.0",
-        "nugetVersion": "5.4.0",
+        "nugetVersion": "5.4.0.1",
         "nugetId": "Square.OkHttp3.UrlConnection",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4726,7 +4726,7 @@
         "groupId": "com.squareup.okio",
         "artifactId": "okio",
         "version": "3.17.0",
-        "nugetVersion": "3.17.0",
+        "nugetVersion": "3.17.0.1",
         "nugetId": "Square.OkIO",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4735,7 +4735,7 @@
         "groupId": "com.squareup.okio",
         "artifactId": "okio-jvm",
         "version": "3.17.0",
-        "nugetVersion": "3.17.0",
+        "nugetVersion": "3.17.0.1",
         "nugetId": "Square.OkIO.JVM",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4744,7 +4744,7 @@
         "groupId": "com.squareup.picasso",
         "artifactId": "picasso",
         "version": "2.8",
-        "nugetVersion": "2.8.0.22",
+        "nugetVersion": "2.8.0.23",
         "nugetId": "Square.Picasso",
         "frozen": true,
         "type": "androidlibrary",
@@ -4754,7 +4754,7 @@
         "groupId": "com.squareup.retrofit",
         "artifactId": "retrofit",
         "version": "1.9.0",
-        "nugetVersion": "1.9.0.23",
+        "nugetVersion": "1.9.0.24",
         "nugetId": "Square.Retrofit",
         "excludedRuntimeDependencies": "com.squareup.okhttp.okhttp,com.google.code.gson.gson,com.google.android.android,io.reactivex.rxjava,com.google.appengine.appengine-api-1.0-sdk",
         "type": "androidlibrary",
@@ -4764,7 +4764,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "adapter-rxjava2",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0.3",
+        "nugetVersion": "3.0.0.4",
         "nugetId": "Square.Retrofit2.AdapterRxJava2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4773,7 +4773,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "converter-gson",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0.3",
+        "nugetVersion": "3.0.0.4",
         "nugetId": "Square.Retrofit2.ConverterGson",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4782,7 +4782,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "converter-scalars",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0.3",
+        "nugetVersion": "3.0.0.4",
         "nugetId": "Square.Retrofit2.ConverterScalars",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4791,7 +4791,7 @@
         "groupId": "com.squareup.retrofit2",
         "artifactId": "retrofit",
         "version": "3.0.0",
-        "nugetVersion": "3.0.0.3",
+        "nugetVersion": "3.0.0.4",
         "nugetId": "Square.Retrofit2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4800,7 +4800,7 @@
         "groupId": "dev.chrisbanes.snapper",
         "artifactId": "snapper",
         "version": "0.3.0",
-        "nugetVersion": "0.3.0.22",
+        "nugetVersion": "0.3.0.23",
         "nugetId": "Xamarin.Dev.ChrisBanes.Snapper",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4809,7 +4809,7 @@
         "groupId": "io.antmedia",
         "artifactId": "rtmp-client",
         "version": "3.2.0",
-        "nugetVersion": "3.2.0.9",
+        "nugetVersion": "3.2.0.10",
         "nugetId": "Xamarin.Android.AntMedia.RtmpClient",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4818,7 +4818,7 @@
         "groupId": "io.github.aakira",
         "artifactId": "napier",
         "version": "2.7.1",
-        "nugetVersion": "2.7.1.14",
+        "nugetVersion": "2.7.1.15",
         "nugetId": "Xamarin.AAkira.Napier",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4827,7 +4827,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-android",
         "version": "1.82.0",
-        "nugetVersion": "1.82.0",
+        "nugetVersion": "1.82.0.1",
         "nugetId": "Xamarin.Grpc.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4836,7 +4836,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-api",
         "version": "1.82.0",
-        "nugetVersion": "1.82.0",
+        "nugetVersion": "1.82.0.1",
         "nugetId": "Xamarin.Grpc.Api",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4845,7 +4845,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-context",
         "version": "1.82.0",
-        "nugetVersion": "1.82.0",
+        "nugetVersion": "1.82.0.1",
         "nugetId": "Xamarin.Grpc.Context",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4854,7 +4854,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-core",
         "version": "1.82.0",
-        "nugetVersion": "1.82.0",
+        "nugetVersion": "1.82.0.1",
         "nugetId": "Xamarin.Grpc.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4863,7 +4863,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-okhttp",
         "version": "1.82.0",
-        "nugetVersion": "1.82.0",
+        "nugetVersion": "1.82.0.1",
         "nugetId": "Xamarin.Grpc.OkHttp",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4872,7 +4872,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-protobuf-lite",
         "version": "1.82.0",
-        "nugetVersion": "1.82.0",
+        "nugetVersion": "1.82.0.1",
         "nugetId": "Xamarin.Grpc.Protobuf.Lite",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4881,7 +4881,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-stub",
         "version": "1.82.0",
-        "nugetVersion": "1.82.0",
+        "nugetVersion": "1.82.0.1",
         "nugetId": "Xamarin.Grpc.Stub",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4890,7 +4890,7 @@
         "groupId": "io.grpc",
         "artifactId": "grpc-util",
         "version": "1.82.0",
-        "nugetVersion": "1.82.0",
+        "nugetVersion": "1.82.0.1",
         "nugetId": "Xamarin.Grpc.Util",
         "excludedRuntimeDependencies": "io.grpc.grpc-core,junit.junit,io.grpc.grpc-testing,org.mockito.mockito-core",
         "type": "androidlibrary",
@@ -4900,7 +4900,7 @@
         "groupId": "io.opencensus",
         "artifactId": "opencensus-api",
         "version": "0.31.1",
-        "nugetVersion": "0.31.1.16",
+        "nugetVersion": "0.31.1.17",
         "nugetId": "Xamarin.Io.OpenCensus.OpenCensusApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4909,7 +4909,7 @@
         "groupId": "io.opencensus",
         "artifactId": "opencensus-contrib-grpc-metrics",
         "version": "0.31.1",
-        "nugetVersion": "0.31.1.16",
+        "nugetVersion": "0.31.1.17",
         "nugetId": "Xamarin.Io.OpenCensus.OpenCensusContribGrpcMetrics",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4918,7 +4918,7 @@
         "groupId": "io.perfmark",
         "artifactId": "perfmark-api",
         "version": "0.27.0",
-        "nugetVersion": "0.27.0.11",
+        "nugetVersion": "0.27.0.12",
         "nugetId": "Xamarin.Io.PerfMark.PerfMarkApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4927,7 +4927,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxandroid",
         "version": "2.1.1",
-        "nugetVersion": "2.1.1.22",
+        "nugetVersion": "2.1.1.23",
         "nugetId": "Xamarin.Android.ReactiveX.RxAndroid",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4936,7 +4936,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxjava",
         "version": "2.2.21",
-        "nugetVersion": "2.2.21.29",
+        "nugetVersion": "2.2.21.30",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -4946,7 +4946,7 @@
         "groupId": "io.reactivex.rxjava2",
         "artifactId": "rxkotlin",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0.22",
+        "nugetVersion": "2.4.0.23",
         "nugetId": "Xamarin.Android.ReactiveX.RxKotlin",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4955,7 +4955,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxandroid",
         "version": "3.0.2",
-        "nugetVersion": "3.0.2.21",
+        "nugetVersion": "3.0.2.22",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxAndroid",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4964,7 +4964,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxjava",
         "version": "3.1.12",
-        "nugetVersion": "3.1.12.2",
+        "nugetVersion": "3.1.12.3",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxJava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4973,7 +4973,7 @@
         "groupId": "io.reactivex.rxjava3",
         "artifactId": "rxkotlin",
         "version": "3.0.1",
-        "nugetVersion": "3.0.1.22",
+        "nugetVersion": "3.0.1.23",
         "nugetId": "Xamarin.Android.ReactiveX.RxJava3.RxKotlin",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4982,7 +4982,7 @@
         "groupId": "jakarta.inject",
         "artifactId": "jakarta.inject-api",
         "version": "2.0.1",
-        "nugetVersion": "2.0.1.9",
+        "nugetVersion": "2.0.1.10",
         "nugetId": "Xamarin.Jakarta.Inject.InjectApi",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -4991,7 +4991,7 @@
         "groupId": "javax.inject",
         "artifactId": "javax.inject",
         "version": "1",
-        "nugetVersion": "1.0.0.23",
+        "nugetVersion": "1.0.0.24",
         "nugetId": "Xamarin.JavaX.Inject",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5000,7 +5000,7 @@
         "groupId": "org.aomedia.avif.android",
         "artifactId": "avif",
         "version": "1.1.1.14d8e3c4",
-        "nugetVersion": "1.1.1.349758411",
+        "nugetVersion": "1.1.1.349758412",
         "nugetId": "Xamarin.AOMedia.AVIF.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -5010,7 +5010,7 @@
         "groupId": "org.brotli",
         "artifactId": "dec",
         "version": "0.1.2",
-        "nugetVersion": "0.1.2.11",
+        "nugetVersion": "0.1.2.12",
         "nugetId": "Xamarin.Brotli.Dec",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5019,7 +5019,7 @@
         "groupId": "org.checkerframework",
         "artifactId": "checker-compat-qual",
         "version": "2.5.6",
-        "nugetVersion": "2.5.6.15",
+        "nugetVersion": "2.5.6.16",
         "nugetId": "Xamarin.CheckerFramework.CheckerCompatQual",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -5028,7 +5028,7 @@
         "groupId": "org.checkerframework",
         "artifactId": "checker-qual",
         "version": "4.2.0",
-        "nugetVersion": "4.2.0",
+        "nugetVersion": "4.2.0.1",
         "nugetId": "Xamarin.CheckerFramework.CheckerQual",
         "type": "no-bindings",
         "mavenRepositoryType": "MavenCentral"
@@ -5037,7 +5037,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-api",
         "version": "143.7445.0",
-        "nugetVersion": "143.7445.0.1",
+        "nugetVersion": "143.7445.0.2",
         "nugetId": "Xamarin.Chromium.CroNet.Api",
         "type": "androidlibrary"
       },
@@ -5045,7 +5045,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-common",
         "version": "143.7445.0",
-        "nugetVersion": "143.7445.0.1",
+        "nugetVersion": "143.7445.0.2",
         "nugetId": "Xamarin.Chromium.CroNet.Common",
         "type": "androidlibrary"
       },
@@ -5053,7 +5053,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-embedded",
         "version": "143.7445.0",
-        "nugetVersion": "143.7445.0.1",
+        "nugetVersion": "143.7445.0.2",
         "nugetId": "Xamarin.Chromium.CroNet.Embedded",
         "type": "androidlibrary"
       },
@@ -5061,7 +5061,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-fallback",
         "version": "143.7445.0",
-        "nugetVersion": "143.7445.0.1",
+        "nugetVersion": "143.7445.0.2",
         "nugetId": "Xamarin.Chromium.CroNet.Fallback",
         "type": "androidlibrary"
       },
@@ -5069,7 +5069,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "cronet-shared",
         "version": "143.7445.0",
-        "nugetVersion": "143.7445.0.1",
+        "nugetVersion": "143.7445.0.2",
         "nugetId": "Xamarin.Chromium.CroNet.Shared",
         "type": "androidlibrary"
       },
@@ -5077,7 +5077,7 @@
         "groupId": "org.chromium.net",
         "artifactId": "httpengine-native-provider",
         "version": "143.7445.0",
-        "nugetVersion": "143.7445.0.1",
+        "nugetVersion": "143.7445.0.2",
         "nugetId": "Xamarin.Chromium.CroNet.HttpEngine.Native.Provider",
         "type": "androidlibrary"
       },
@@ -5085,7 +5085,7 @@
         "groupId": "org.codehaus.mojo",
         "artifactId": "animal-sniffer-annotations",
         "version": "1.27",
-        "nugetVersion": "1.27.0.1",
+        "nugetVersion": "1.27.0.2",
         "nugetId": "Xamarin.CodeHaus.Mojo.AnimalSnifferAnnotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5094,7 +5094,7 @@
         "groupId": "org.jetbrains",
         "artifactId": "annotations",
         "version": "26.1.0",
-        "nugetVersion": "26.1.0.1",
+        "nugetVersion": "26.1.0.2",
         "nugetId": "Xamarin.Jetbrains.Annotations",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5103,7 +5103,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-android-extensions-runtime",
         "version": "2.2.10",
-        "nugetVersion": "2.2.10.2",
+        "nugetVersion": "2.2.10.3",
         "nugetId": "Xamarin.Kotlin.Android.Extensions.Runtime.Library",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5112,7 +5112,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-parcelize-runtime",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0",
+        "nugetVersion": "2.4.0.1",
         "nugetId": "Xamarin.Kotlin.Parcelize.Runtime",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5121,7 +5121,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-reflect",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0",
+        "nugetVersion": "2.4.0.1",
         "nugetId": "Xamarin.Kotlin.Reflect",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -5133,7 +5133,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0",
+        "nugetVersion": "2.4.0.1",
         "nugetId": "Xamarin.Kotlin.StdLib",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5142,7 +5142,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-common",
         "version": "2.0.21",
-        "nugetVersion": "2.0.21.7",
+        "nugetVersion": "2.0.21.8",
         "nugetId": "Xamarin.Kotlin.StdLib.Common",
         "frozen": true,
         "type": "androidlibrary",
@@ -5155,7 +5155,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk7",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0",
+        "nugetVersion": "2.4.0.1",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk7",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -5167,7 +5167,7 @@
         "groupId": "org.jetbrains.kotlin",
         "artifactId": "kotlin-stdlib-jdk8",
         "version": "2.4.0",
-        "nugetVersion": "2.4.0",
+        "nugetVersion": "2.4.0.1",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk8",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral",
@@ -5179,7 +5179,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "atomicfu",
         "version": "0.33.0",
-        "nugetVersion": "0.33.0",
+        "nugetVersion": "0.33.0.1",
         "nugetId": "Xamarin.KotlinX.AtomicFU",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5188,7 +5188,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "atomicfu-jvm",
         "version": "0.33.0",
-        "nugetVersion": "0.33.0",
+        "nugetVersion": "0.33.0.1",
         "nugetId": "Xamarin.KotlinX.AtomicFU.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5197,7 +5197,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-android",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Android",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5206,7 +5206,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5215,7 +5215,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-core-jvm",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Core.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5224,7 +5224,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-guava",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Guava",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5233,7 +5233,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-jdk8",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Jdk8",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5242,7 +5242,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-play-services",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Play.Services",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5251,7 +5251,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-reactive",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Reactive",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5260,7 +5260,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx2",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx2",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5269,7 +5269,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-coroutines-rx3",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Coroutines.Rx3",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5278,7 +5278,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-core",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Core",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5287,7 +5287,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-core-jvm",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Core.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5296,7 +5296,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-json",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Json",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5305,7 +5305,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-json-jvm",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Json.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5314,7 +5314,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-protobuf",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Protobuf",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5323,7 +5323,7 @@
         "groupId": "org.jetbrains.kotlinx",
         "artifactId": "kotlinx-serialization-protobuf-jvm",
         "version": "1.11.0",
-        "nugetVersion": "1.11.0",
+        "nugetVersion": "1.11.0.1",
         "nugetId": "Xamarin.KotlinX.Serialization.Protobuf.Jvm",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5332,7 +5332,7 @@
         "groupId": "org.jspecify",
         "artifactId": "jspecify",
         "version": "1.0.0",
-        "nugetVersion": "1.0.0.6",
+        "nugetVersion": "1.0.0.7",
         "nugetId": "Xamarin.JSpecify",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5341,7 +5341,7 @@
         "groupId": "org.ow2.asm",
         "artifactId": "asm",
         "version": "9.10.1",
-        "nugetVersion": "9.10.1",
+        "nugetVersion": "9.10.1.1",
         "nugetId": "Xamarin.OW2.ASM",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5350,7 +5350,7 @@
         "groupId": "org.reactivestreams",
         "artifactId": "reactive-streams",
         "version": "1.0.4",
-        "nugetVersion": "1.0.4.23",
+        "nugetVersion": "1.0.4.24",
         "nugetId": "Xamarin.Android.ReactiveStreams",
         "type": "androidlibrary",
         "mavenRepositoryType": "MavenCentral"
@@ -5359,7 +5359,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-android",
         "version": "1.13.1",
-        "nugetVersion": "1.13.1.17",
+        "nugetVersion": "1.13.1.18",
         "nugetId": "Xamarin.TensorFlow.Android",
         "assemblyName": "org.tensorflow.tensorflow-android",
         "type": "androidlibrary",
@@ -5369,7 +5369,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.9",
+        "nugetVersion": "2.16.1.10",
         "nugetId": "Xamarin.TensorFlow.Lite",
         "frozen": true,
         "type": "androidlibrary",
@@ -5380,7 +5380,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-api",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.9",
+        "nugetVersion": "2.16.1.10",
         "nugetId": "Xamarin.TensorFlow.Lite.Api",
         "frozen": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-api",
@@ -5392,7 +5392,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-gpu",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.9",
+        "nugetVersion": "2.16.1.10",
         "nugetId": "Xamarin.TensorFlow.Lite.Gpu",
         "frozen": true,
         "type": "androidlibrary",
@@ -5403,7 +5403,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-gpu-api",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.9",
+        "nugetVersion": "2.16.1.10",
         "nugetId": "Xamarin.TensorFlow.Lite.Gpu.Api",
         "frozen": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-gpu-api",
@@ -5415,7 +5415,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-metadata",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.5",
+        "nugetVersion": "0.5.0.6",
         "nugetId": "Xamarin.TensorFlow.Lite.Metadata",
         "assemblyName": "org.tensorflow.tensorflow-lite-metadata",
         "type": "androidlibrary",
@@ -5425,7 +5425,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-select-tf-ops",
         "version": "2.16.1",
-        "nugetVersion": "2.16.1.9",
+        "nugetVersion": "2.16.1.10",
         "nugetId": "Xamarin.TensorFlow.Lite.Select.TF.Ops",
         "assemblyName": "org.tensorflow.tensorflow-lite-select-tf-ops",
         "type": "androidlibrary",
@@ -5435,7 +5435,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-support",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.5",
+        "nugetVersion": "0.5.0.6",
         "nugetId": "Xamarin.TensorFlow.Lite.Support.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-support",
         "type": "androidlibrary",
@@ -5445,7 +5445,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-support-api",
         "version": "0.5.0",
-        "nugetVersion": "0.5.0.5",
+        "nugetVersion": "0.5.0.6",
         "nugetId": "Xamarin.TensorFlow.Lite.Support.Api",
         "allowPrereleaseDependencies": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-support-api",
@@ -5457,7 +5457,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-audio",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.14",
+        "nugetVersion": "0.4.4.15",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Audio.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-audio",
         "type": "androidlibrary",
@@ -5467,7 +5467,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-audio-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.14",
+        "nugetVersion": "0.4.4.15",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Audio.PlayServices.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-audio-play-services",
         "type": "androidlibrary",
@@ -5477,7 +5477,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-base",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.14",
+        "nugetVersion": "0.4.4.15",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Base.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-base",
         "type": "androidlibrary",
@@ -5487,7 +5487,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-text",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.14",
+        "nugetVersion": "0.4.4.15",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Text.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-text",
         "type": "androidlibrary",
@@ -5497,7 +5497,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-text-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.14",
+        "nugetVersion": "0.4.4.15",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Text.PlayServices.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-text-play-services",
         "type": "androidlibrary",
@@ -5507,7 +5507,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-vision",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.14",
+        "nugetVersion": "0.4.4.15",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Vision.Library",
         "assemblyName": "org.tensorflow.tensorflow-lite-task-vision",
         "type": "androidlibrary",
@@ -5517,7 +5517,7 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-task-vision-play-services",
         "version": "0.4.4",
-        "nugetVersion": "0.4.4.14",
+        "nugetVersion": "0.4.4.15",
         "nugetId": "Xamarin.TensorFlow.Lite.Task.Vision.PlayServices.Library",
         "allowPrereleaseDependencies": true,
         "assemblyName": "org.tensorflow.tensorflow-lite-task-vision-play-services",


### PR DESCRIPTION
## Summary

Bump the last component (revision) of all `nugetVersion` entries in `config.json` by +1 across all 713 packages.

## Reason

When upgrading Android packages in the [dotnet/maui](https://github.com/dotnet/maui) repository, there are numerous dependency resolution issues caused by misaligned package versions. Packages reference dependency versions that don't exist or conflict with each other, preventing a clean NuGet restore.

This alignment bump ensures all packages are published at a consistent revision so that the dependency graph resolves correctly when consumed by .NET MAUI (and other downstream projects).

## Changes

- Incremented the 4th version component of every `nugetVersion` in `config.json` by 1
  - 3-part versions get a `.1` appended (e.g. `1.13.0` → `1.13.0.1`)
  - 4-part versions get the last component incremented (e.g. `1.0.0.35-alpha05` → `1.0.0.36-alpha05`)

Similar to #1337.