### PR TITLE
Fix Material Slider ACW implementor build failure (#1484)

### DIFF
--- a/config.json
+++ b/config.json
@@ -3518,7 +3518,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.14.0",
-        "nugetVersion": "1.14.0.3",
+        "nugetVersion": "1.14.0.4",
         "nugetId": "Xamarin.Google.Android.Material",
         "comments": "Requires API-34"
       },

--- a/source/com.google.android.material/material/Additions/SliderListenerMethods.cs
+++ b/source/com.google.android.material/material/Additions/SliderListenerMethods.cs
@@ -22,8 +22,14 @@ public partial class Slider
         const string __id = "addOnChangeListener." + _addOnChangeListenerJni;
         Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
         __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
-        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
-        GC.KeepAlive(listener);
+        try
+        {
+            _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        }
+        finally
+        {
+            GC.KeepAlive(listener);
+        }
     }
 
     public unsafe void RemoveOnChangeListener(Slider.IOnChangeListener listener)
@@ -31,8 +37,14 @@ public partial class Slider
         const string __id = "removeOnChangeListener." + _removeOnChangeListenerJni;
         Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
         __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
-        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
-        GC.KeepAlive(listener);
+        try
+        {
+            _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        }
+        finally
+        {
+            GC.KeepAlive(listener);
+        }
     }
 
     public unsafe void AddOnSliderTouchListener(Slider.IOnSliderTouchListener listener)
@@ -40,8 +52,14 @@ public partial class Slider
         const string __id = "addOnSliderTouchListener." + _addOnSliderTouchListenerJni;
         Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
         __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
-        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
-        GC.KeepAlive(listener);
+        try
+        {
+            _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        }
+        finally
+        {
+            GC.KeepAlive(listener);
+        }
     }
 
     public unsafe void RemoveOnSliderTouchListener(Slider.IOnSliderTouchListener listener)
@@ -49,8 +67,14 @@ public partial class Slider
         const string __id = "removeOnSliderTouchListener." + _removeOnSliderTouchListenerJni;
         Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
         __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
-        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
-        GC.KeepAlive(listener);
+        try
+        {
+            _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        }
+        finally
+        {
+            GC.KeepAlive(listener);
+        }
     }
 }
 
@@ -66,8 +90,14 @@ public partial class RangeSlider
         const string __id = "addOnChangeListener." + _addOnChangeListenerJni;
         Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
         __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
-        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
-        GC.KeepAlive(listener);
+        try
+        {
+            _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        }
+        finally
+        {
+            GC.KeepAlive(listener);
+        }
     }
 
     public unsafe void RemoveOnChangeListener(RangeSlider.IOnChangeListener listener)
@@ -75,8 +105,14 @@ public partial class RangeSlider
         const string __id = "removeOnChangeListener." + _removeOnChangeListenerJni;
         Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
         __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
-        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
-        GC.KeepAlive(listener);
+        try
+        {
+            _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        }
+        finally
+        {
+            GC.KeepAlive(listener);
+        }
     }
 
     public unsafe void AddOnSliderTouchListener(RangeSlider.IOnSliderTouchListener listener)
@@ -84,8 +120,14 @@ public partial class RangeSlider
         const string __id = "addOnSliderTouchListener." + _addOnSliderTouchListenerJni;
         Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
         __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
-        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
-        GC.KeepAlive(listener);
+        try
+        {
+            _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        }
+        finally
+        {
+            GC.KeepAlive(listener);
+        }
     }
 
     public unsafe void RemoveOnSliderTouchListener(RangeSlider.IOnSliderTouchListener listener)
@@ -93,8 +135,14 @@ public partial class RangeSlider
         const string __id = "removeOnSliderTouchListener." + _removeOnSliderTouchListenerJni;
         Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
         __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
-        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
-        GC.KeepAlive(listener);
+        try
+        {
+            _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        }
+        finally
+        {
+            GC.KeepAlive(listener);
+        }
     }
 }
 

--- a/source/com.google.android.material/material/Additions/SliderListenerMethods.cs
+++ b/source/com.google.android.material/material/Additions/SliderListenerMethods.cs
@@ -1,0 +1,100 @@
+using System;
+using Android.Runtime;
+
+namespace Google.Android.Material.Slider;
+
+// Hand-written add/remove listener methods for Slider and RangeSlider.
+// The auto-generated versions are removed from Metadata.xml because the base interfaces
+// (BaseOnChangeListener, BaseOnSliderTouchListener) use erased generics that cause
+// ACW type erasure clashes and implementor failures. These manual implementations use
+// the correct JNI signature while accepting the typed sub-interfaces directly.
+// This pattern (remove in metadata + re-add in Additions) is standard in .NET Android bindings.
+
+public partial class Slider
+{
+    const string _addOnChangeListenerJni = "(Lcom/google/android/material/slider/BaseOnChangeListener;)V";
+    const string _removeOnChangeListenerJni = "(Lcom/google/android/material/slider/BaseOnChangeListener;)V";
+    const string _addOnSliderTouchListenerJni = "(Lcom/google/android/material/slider/BaseOnSliderTouchListener;)V";
+    const string _removeOnSliderTouchListenerJni = "(Lcom/google/android/material/slider/BaseOnSliderTouchListener;)V";
+
+    public unsafe void AddOnChangeListener(Slider.IOnChangeListener listener)
+    {
+        const string __id = "addOnChangeListener." + _addOnChangeListenerJni;
+        Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
+        __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
+        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        GC.KeepAlive(listener);
+    }
+
+    public unsafe void RemoveOnChangeListener(Slider.IOnChangeListener listener)
+    {
+        const string __id = "removeOnChangeListener." + _removeOnChangeListenerJni;
+        Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
+        __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
+        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        GC.KeepAlive(listener);
+    }
+
+    public unsafe void AddOnSliderTouchListener(Slider.IOnSliderTouchListener listener)
+    {
+        const string __id = "addOnSliderTouchListener." + _addOnSliderTouchListenerJni;
+        Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
+        __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
+        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        GC.KeepAlive(listener);
+    }
+
+    public unsafe void RemoveOnSliderTouchListener(Slider.IOnSliderTouchListener listener)
+    {
+        const string __id = "removeOnSliderTouchListener." + _removeOnSliderTouchListenerJni;
+        Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
+        __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
+        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        GC.KeepAlive(listener);
+    }
+}
+
+public partial class RangeSlider
+{
+    const string _addOnChangeListenerJni = "(Lcom/google/android/material/slider/BaseOnChangeListener;)V";
+    const string _removeOnChangeListenerJni = "(Lcom/google/android/material/slider/BaseOnChangeListener;)V";
+    const string _addOnSliderTouchListenerJni = "(Lcom/google/android/material/slider/BaseOnSliderTouchListener;)V";
+    const string _removeOnSliderTouchListenerJni = "(Lcom/google/android/material/slider/BaseOnSliderTouchListener;)V";
+
+    public unsafe void AddOnChangeListener(RangeSlider.IOnChangeListener listener)
+    {
+        const string __id = "addOnChangeListener." + _addOnChangeListenerJni;
+        Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
+        __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
+        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        GC.KeepAlive(listener);
+    }
+
+    public unsafe void RemoveOnChangeListener(RangeSlider.IOnChangeListener listener)
+    {
+        const string __id = "removeOnChangeListener." + _removeOnChangeListenerJni;
+        Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
+        __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
+        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        GC.KeepAlive(listener);
+    }
+
+    public unsafe void AddOnSliderTouchListener(RangeSlider.IOnSliderTouchListener listener)
+    {
+        const string __id = "addOnSliderTouchListener." + _addOnSliderTouchListenerJni;
+        Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
+        __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
+        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        GC.KeepAlive(listener);
+    }
+
+    public unsafe void RemoveOnSliderTouchListener(RangeSlider.IOnSliderTouchListener listener)
+    {
+        const string __id = "removeOnSliderTouchListener." + _removeOnSliderTouchListenerJni;
+        Java.Interop.JniArgumentValue* __args = stackalloc Java.Interop.JniArgumentValue[1];
+        __args[0] = new Java.Interop.JniArgumentValue(listener == null ? IntPtr.Zero : ((Java.Lang.Object)listener).Handle);
+        _members.InstanceMethods.InvokeVirtualVoidMethod(__id, this, __args);
+        GC.KeepAlive(listener);
+    }
+}
+

--- a/source/com.google.android.material/material/PublicAPI/PublicAPI.Unshipped.txt
+++ b/source/com.google.android.material/material/PublicAPI/PublicAPI.Unshipped.txt
@@ -1982,8 +1982,6 @@ Google.Android.Material.Slider.BasicLabelFormatter
 Google.Android.Material.Slider.BasicLabelFormatter.BasicLabelFormatter() -> void
 Google.Android.Material.Slider.BasicLabelFormatter.GetFormattedValue(float value) -> string!
 Google.Android.Material.Slider.BasicLabelFormatter.InterfaceConsts
-Google.Android.Material.Slider.IBaseOnChangeListener
-Google.Android.Material.Slider.IBaseOnSliderTouchListener
 Google.Android.Material.Slider.ILabelFormatter
 Google.Android.Material.Slider.ILabelFormatter.GetFormattedValue(float p0) -> string!
 Google.Android.Material.Slider.ISliderOrientation
@@ -1991,6 +1989,13 @@ Google.Android.Material.Slider.ITickVisibilityMode
 Google.Android.Material.Slider.LabelFormatter
 Google.Android.Material.Slider.LabelFormatterConsts
 Google.Android.Material.Slider.RangeSlider
+Google.Android.Material.Slider.RangeSlider.AddOnChangeListener(Google.Android.Material.Slider.RangeSlider.IOnChangeListener! listener) -> void
+Google.Android.Material.Slider.RangeSlider.AddOnSliderTouchListener(Google.Android.Material.Slider.RangeSlider.IOnSliderTouchListener! listener) -> void
+Google.Android.Material.Slider.RangeSlider.ChangeEventArgs
+Google.Android.Material.Slider.RangeSlider.ChangeEventArgs.ChangeEventArgs(Google.Android.Material.Slider.RangeSlider! p0, float p1, bool p2) -> void
+Google.Android.Material.Slider.RangeSlider.ChangeEventArgs.P0.get -> Google.Android.Material.Slider.RangeSlider!
+Google.Android.Material.Slider.RangeSlider.ChangeEventArgs.P1.get -> float
+Google.Android.Material.Slider.RangeSlider.ChangeEventArgs.P2.get -> bool
 Google.Android.Material.Slider.RangeSlider.IOnChangeListener
 Google.Android.Material.Slider.RangeSlider.IOnChangeListener.OnValueChange(Google.Android.Material.Slider.RangeSlider! p0, float p1, bool p2) -> void
 Google.Android.Material.Slider.RangeSlider.IOnSliderTouchListener
@@ -2000,17 +2005,40 @@ Google.Android.Material.Slider.RangeSlider.RangeSlider(Android.Content.Context! 
 Google.Android.Material.Slider.RangeSlider.RangeSlider(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
 Google.Android.Material.Slider.RangeSlider.RangeSlider(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
 Google.Android.Material.Slider.RangeSlider.RangeSlider(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Google.Android.Material.Slider.RangeSlider.RemoveOnChangeListener(Google.Android.Material.Slider.RangeSlider.IOnChangeListener! listener) -> void
+Google.Android.Material.Slider.RangeSlider.RemoveOnSliderTouchListener(Google.Android.Material.Slider.RangeSlider.IOnSliderTouchListener! listener) -> void
+Google.Android.Material.Slider.RangeSlider.StartTrackingTouchEventArgs
+Google.Android.Material.Slider.RangeSlider.StartTrackingTouchEventArgs.P0.get -> Google.Android.Material.Slider.RangeSlider!
+Google.Android.Material.Slider.RangeSlider.StartTrackingTouchEventArgs.StartTrackingTouchEventArgs(Google.Android.Material.Slider.RangeSlider! p0) -> void
+Google.Android.Material.Slider.RangeSlider.StopTrackingTouchEventArgs
+Google.Android.Material.Slider.RangeSlider.StopTrackingTouchEventArgs.P0.get -> Google.Android.Material.Slider.RangeSlider!
+Google.Android.Material.Slider.RangeSlider.StopTrackingTouchEventArgs.StopTrackingTouchEventArgs(Google.Android.Material.Slider.RangeSlider! p0) -> void
 Google.Android.Material.Slider.Slider
+Google.Android.Material.Slider.Slider.AddOnChangeListener(Google.Android.Material.Slider.Slider.IOnChangeListener! listener) -> void
+Google.Android.Material.Slider.Slider.AddOnSliderTouchListener(Google.Android.Material.Slider.Slider.IOnSliderTouchListener! listener) -> void
+Google.Android.Material.Slider.Slider.ChangeEventArgs
+Google.Android.Material.Slider.Slider.ChangeEventArgs.ChangeEventArgs(Google.Android.Material.Slider.Slider! p0, float p1, bool p2) -> void
+Google.Android.Material.Slider.Slider.ChangeEventArgs.P0.get -> Google.Android.Material.Slider.Slider!
+Google.Android.Material.Slider.Slider.ChangeEventArgs.P1.get -> float
+Google.Android.Material.Slider.Slider.ChangeEventArgs.P2.get -> bool
 Google.Android.Material.Slider.Slider.IOnChangeListener
 Google.Android.Material.Slider.Slider.IOnChangeListener.OnValueChange(Google.Android.Material.Slider.Slider! p0, float p1, bool p2) -> void
 Google.Android.Material.Slider.Slider.IOnSliderTouchListener
 Google.Android.Material.Slider.Slider.IOnSliderTouchListener.OnStartTrackingTouch(Google.Android.Material.Slider.Slider! p0) -> void
 Google.Android.Material.Slider.Slider.IOnSliderTouchListener.OnStopTrackingTouch(Google.Android.Material.Slider.Slider! p0) -> void
+Google.Android.Material.Slider.Slider.RemoveOnChangeListener(Google.Android.Material.Slider.Slider.IOnChangeListener! listener) -> void
+Google.Android.Material.Slider.Slider.RemoveOnSliderTouchListener(Google.Android.Material.Slider.Slider.IOnSliderTouchListener! listener) -> void
 Google.Android.Material.Slider.Slider.SetEnabled(bool p0) -> void
 Google.Android.Material.Slider.Slider.Slider(Android.Content.Context! context) -> void
 Google.Android.Material.Slider.Slider.Slider(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
 Google.Android.Material.Slider.Slider.Slider(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
 Google.Android.Material.Slider.Slider.Slider(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Google.Android.Material.Slider.Slider.StartTrackingTouchEventArgs
+Google.Android.Material.Slider.Slider.StartTrackingTouchEventArgs.P0.get -> Google.Android.Material.Slider.Slider!
+Google.Android.Material.Slider.Slider.StartTrackingTouchEventArgs.StartTrackingTouchEventArgs(Google.Android.Material.Slider.Slider! p0) -> void
+Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs
+Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs.P0.get -> Google.Android.Material.Slider.Slider!
+Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs.StopTrackingTouchEventArgs(Google.Android.Material.Slider.Slider! p0) -> void
 Google.Android.Material.Slider.SliderOrientation
 Google.Android.Material.Slider.SliderOrientationConsts
 Google.Android.Material.Slider.TickVisibilityMode
@@ -6721,8 +6749,6 @@ virtual Google.Android.Material.SideSheet.SideSheetDialog.DismissWithSheetAnimat
 virtual Google.Android.Material.SideSheet.SideSheetDialog.SetFitsSystemWindows(bool p0) -> void
 virtual Google.Android.Material.SideSheet.SideSheetDialog.SetSheetEdge(int p0) -> void
 virtual Google.Android.Material.Slider.RangeSlider.ActiveThumbIndex.get -> int
-virtual Google.Android.Material.Slider.RangeSlider.AddOnChangeListener(Google.Android.Material.Slider.IBaseOnChangeListener! listener) -> void
-virtual Google.Android.Material.Slider.RangeSlider.AddOnSliderTouchListener(Google.Android.Material.Slider.IBaseOnSliderTouchListener! listener) -> void
 virtual Google.Android.Material.Slider.RangeSlider.Centered.get -> bool
 virtual Google.Android.Material.Slider.RangeSlider.Centered.set -> void
 virtual Google.Android.Material.Slider.RangeSlider.ClearOnChangeListeners() -> void
@@ -6744,8 +6770,6 @@ virtual Google.Android.Material.Slider.RangeSlider.MinSeparation.get -> float
 virtual Google.Android.Material.Slider.RangeSlider.MinSeparation.set -> void
 virtual Google.Android.Material.Slider.RangeSlider.OnSaveInstanceState() -> Android.OS.IParcelable!
 virtual Google.Android.Material.Slider.RangeSlider.PickActiveThumb() -> bool
-virtual Google.Android.Material.Slider.RangeSlider.RemoveOnChangeListener(Google.Android.Material.Slider.IBaseOnChangeListener! listener) -> void
-virtual Google.Android.Material.Slider.RangeSlider.RemoveOnSliderTouchListener(Google.Android.Material.Slider.IBaseOnSliderTouchListener! listener) -> void
 virtual Google.Android.Material.Slider.RangeSlider.ScheduleTooltipTimeout() -> void
 virtual Google.Android.Material.Slider.RangeSlider.SetActiveThumbIndex(int index) -> void
 virtual Google.Android.Material.Slider.RangeSlider.SetCustomThumbDrawable(Android.Graphics.Drawables.Drawable! drawable) -> void
@@ -6838,8 +6862,6 @@ virtual Google.Android.Material.Slider.RangeSlider.ValueTo.set -> void
 virtual Google.Android.Material.Slider.RangeSlider.Values.get -> System.Collections.Generic.IList<Java.Lang.Float!>!
 virtual Google.Android.Material.Slider.RangeSlider.Values.set -> void
 virtual Google.Android.Material.Slider.Slider.ActiveThumbIndex.get -> int
-virtual Google.Android.Material.Slider.Slider.AddOnChangeListener(Google.Android.Material.Slider.IBaseOnChangeListener! listener) -> void
-virtual Google.Android.Material.Slider.Slider.AddOnSliderTouchListener(Google.Android.Material.Slider.IBaseOnSliderTouchListener! listener) -> void
 virtual Google.Android.Material.Slider.Slider.Centered.get -> bool
 virtual Google.Android.Material.Slider.Slider.Centered.set -> void
 virtual Google.Android.Material.Slider.Slider.ClearOnChangeListeners() -> void
@@ -6859,8 +6881,6 @@ virtual Google.Android.Material.Slider.Slider.LabelBehavior.get -> int
 virtual Google.Android.Material.Slider.Slider.LabelBehavior.set -> void
 virtual Google.Android.Material.Slider.Slider.MinSeparation.get -> float
 virtual Google.Android.Material.Slider.Slider.PickActiveThumb() -> bool
-virtual Google.Android.Material.Slider.Slider.RemoveOnChangeListener(Google.Android.Material.Slider.IBaseOnChangeListener! listener) -> void
-virtual Google.Android.Material.Slider.Slider.RemoveOnSliderTouchListener(Google.Android.Material.Slider.IBaseOnSliderTouchListener! listener) -> void
 virtual Google.Android.Material.Slider.Slider.ScheduleTooltipTimeout() -> void
 virtual Google.Android.Material.Slider.Slider.SetActiveThumbIndex(int index) -> void
 virtual Google.Android.Material.Slider.Slider.SetCustomThumbDrawable(Android.Graphics.Drawables.Drawable! drawable) -> void

--- a/source/com.google.android.material/material/Transforms/Metadata.xml
+++ b/source/com.google.android.material/material/Transforms/Metadata.xml
@@ -319,49 +319,43 @@
       com.google.android.material.appbar.AppBarLayout
     </attr>
 
-    <!-- Fix BaseSlider addOnChangeListener and removeOnChangeListener methods -->
-    <attr
-      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='addOnChangeListener' and count(parameter)=1 and parameter[1][@type='L']]/parameter[1]"
-      name="type"
-      >
-      com.google.android.material.slider.BaseOnChangeListener
-    </attr>
-    <attr
-      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='removeOnChangeListener' and count(parameter)=1 and parameter[1][@type='L']]/parameter[1]"
-      name="type"
-      >
-      com.google.android.material.slider.BaseOnChangeListener
-    </attr>
-    
-    <!-- Fix BaseSlider addOnSliderTouchListener and removeOnSliderTouchListener methods -->
-    <attr
-      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='addOnSliderTouchListener' and count(parameter)=1 and parameter[1][@type='T']]/parameter[1]"
-      name="type"
-      >
-      com.google.android.material.slider.BaseOnSliderTouchListener
-    </attr>
-    <attr
-      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='removeOnSliderTouchListener' and count(parameter)=1 and parameter[1][@type='T']]/parameter[1]"
-      name="type"
-      >
-      com.google.android.material.slider.BaseOnSliderTouchListener
-    </attr>
+    <!-- Remove deprecated BaseOnChangeListener and BaseOnSliderTouchListener interfaces entirely.
+         These base interfaces use erased generics that cause ACW type erasure clashes when
+         implemented alongside their typed sub-interfaces (Slider.OnChangeListener, etc.).
+         The binding generator creates Implementor Java classes for any interface referenced in
+         add/removeListener pairs, but these implementors cannot satisfy the Java abstract method
+         contracts because of the erasure. Removing the base interfaces eliminates the
+         implementor generation (no interface type → no implementor). -->
+    <remove-node
+      path="/api/package[@name='com.google.android.material.slider']/interface[@name='BaseOnChangeListener']" />
+    <remove-node
+      path="/api/package[@name='com.google.android.material.slider']/interface[@name='BaseOnSliderTouchListener']" />
 
-    <!-- Remove erased onValueChange from BaseOnChangeListener to prevent ACW type erasure clash.
-         The typed sub-interfaces (Slider.OnChangeListener, RangeSlider.OnChangeListener) provide
-         the concrete onValueChange(Slider/RangeSlider, float, boolean) methods that users implement.
-         Without this, implementing Slider.IOnChangeListener causes Java error:
-         "name clash: class has two methods with the same erasure" because the ACW generates both
-         onValueChange(Object,...) from the base and onValueChange(Slider,...) from the sub-interface. -->
+    <!-- Remove the 'implements BaseOnChangeListener/BaseOnSliderTouchListener' from the typed
+         sub-interfaces so they don't reference the now-removed base types.
+         This makes them standalone interfaces with just their typed methods. -->
     <remove-node
-      path="/api/package[@name='com.google.android.material.slider']/interface[@name='BaseOnChangeListener']/method[@name='onValueChange']" />
+      path="/api/package[@name='com.google.android.material.slider']/interface[@name='Slider.OnChangeListener']/implements[@name='com.google.android.material.slider.BaseOnChangeListener']" />
+    <remove-node
+      path="/api/package[@name='com.google.android.material.slider']/interface[@name='Slider.OnSliderTouchListener']/implements[@name='com.google.android.material.slider.BaseOnSliderTouchListener']" />
+    <remove-node
+      path="/api/package[@name='com.google.android.material.slider']/interface[@name='RangeSlider.OnChangeListener']/implements[@name='com.google.android.material.slider.BaseOnChangeListener']" />
+    <remove-node
+      path="/api/package[@name='com.google.android.material.slider']/interface[@name='RangeSlider.OnSliderTouchListener']/implements[@name='com.google.android.material.slider.BaseOnSliderTouchListener']" />
 
-    <!-- Remove erased onStartTrackingTouch/onStopTrackingTouch from BaseOnSliderTouchListener
-         for the same ACW type erasure reason as above. -->
+    <!-- Remove the add/remove listener methods from BaseSlider to prevent implementor generation.
+         These methods reference the removed base interfaces as parameter types. We re-implement
+         them manually in Additions with typed overloads (Slider.IOnChangeListener, etc.) that
+         use the correct JNI signatures. This is a standard binding pattern: remove problematic
+         auto-generated method, replace with hand-written Additions code. -->
     <remove-node
-      path="/api/package[@name='com.google.android.material.slider']/interface[@name='BaseOnSliderTouchListener']/method[@name='onStartTrackingTouch']" />
+      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='addOnChangeListener']" />
     <remove-node
-      path="/api/package[@name='com.google.android.material.slider']/interface[@name='BaseOnSliderTouchListener']/method[@name='onStopTrackingTouch']" />
+      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='removeOnChangeListener']" />
+    <remove-node
+      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='addOnSliderTouchListener']" />
+    <remove-node
+      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='removeOnSliderTouchListener']" />
 
     <!-- Use discoverable .NET-style casing for newer multi-word Material package namespaces -->
     <attr path="/api/package[@name='com.google.android.material.listitem']" name="managedName">Google.Android.Material.ListItem</attr>


### PR DESCRIPTION
## Summary

Fixes the Java/ACW compile failure consumers hit when referencing the **Xamarin.Google.Android.Material** package in a .NET MAUI Android app — even without using the Slider control. 

Fixes #1484.

```
SliderChangeListener is not abstract and does not override abstract method onValueChange(Object,float,boolean) in BaseOnChangeListener
RangeSliderChangeListener is not abstract and does not override abstract method onValueChange(Object,float,boolean) in BaseOnChangeListener
BaseOnSliderTouchListenerImplementor is not abstract and does not override abstract method onStopTrackingTouch(Object) in BaseOnSliderTouchListener
BaseOnChangeListenerImplementor is not abstract and does not override abstract method onValueChange(Object,float,boolean) in BaseOnChangeListener
```

## Root cause

`BaseOnChangeListener` / `BaseOnSliderTouchListener` are `@RestrictTo(LIBRARY_GROUP)` (internal) base interfaces with **type-erased** generic methods (`onValueChange(Object, float, boolean)`). The public, recommended types are `Slider.OnChangeListener` / `RangeSlider.OnChangeListener`, which extend the base with strongly-typed methods.

Because the bound `add/removeListener` pair references the base interface, the generator emits internal `Implementor` types decorated with `[Register]`. Every consuming app generates Android Callable Wrappers for those `[Register]` types. After PR #1481 stripped the erased base methods (to fix an erasure clash), the implementors and event listeners no longer satisfied the still-present Java abstract methods, so **javac failed in every consuming project**.

## Fix

- Remove the restricted base interfaces `BaseOnChangeListener` / `BaseOnSliderTouchListener` from the binding — this stops the broken `Implementor` generation at the source.
- Break the C# `implements` chain on the four typed sub-interfaces so they stand alone (no longer extending the removed base) — removes the type-erasure clash entirely.
- Remove the auto-generated `addOnChangeListener` / `removeOnChangeListener` / `addOnSliderTouchListener` / `removeOnSliderTouchListener` methods and re-add typed overloads via Additions with the correct JNI signatures.

The public API now exposes the **Android-recommended** listeners:

```csharp
slider.AddOnChangeListener(myListener);   // Slider.IOnChangeListener
slider.AddOnSliderTouchListener(touch);   // Slider.IOnSliderTouchListener
```

`Bump nugetVersion` to `1.14.0.4`.

## Why removal is safe

`BaseOnChangeListener` is `@RestrictTo(LIBRARY_GROUP)` — internal to the Material library, not part of Android's public surface. Dropping it aligns with Google's intent and steers users to `Slider.IOnChangeListener` / `RangeSlider.IOnChangeListener`.

## Validation

- `Xamarin.Google.Android.Material.dll` builds with 0 errors.
- No `*Implementor` ACW types generated for the listeners.
- Typed sub-interfaces preserved; PublicAPI updated accordingly.

## Files changed

- `source/com.google.android.material/material/Transforms/Metadata.xml`
- `source/com.google.android.material/material/Additions/SliderListenerMethods.cs` (new)
- `source/com.google.android.material/material/PublicAPI/PublicAPI.Unshipped.txt`
- `config.json` (nugetVersion 1.14.0.3 → 1.14.0.4)
