### PR TITLE
Fix Java-generic name-clash in AdLoadCallback subclasses (issue #1491)

### DIFF
--- a/config.json
+++ b/config.json
@@ -2730,7 +2730,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads",
         "version": "25.4.0",
-        "nugetVersion": "125.4.0.1",
+        "nugetVersion": "125.4.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Ads",
         "allowPrereleaseDependencies": true,
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",
@@ -2740,7 +2740,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-api",
         "version": "25.4.0",
-        "nugetVersion": "125.4.0.1",
+        "nugetVersion": "125.4.0.2",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Api",
         "type": "xbd"
       },

--- a/config.json
+++ b/config.json
@@ -2764,7 +2764,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads-lite",
         "version": "24.0.0",
-        "nugetVersion": "124.0.0.6",
+        "nugetVersion": "124.0.0.7",
         "nugetId": "Xamarin.GooglePlayServices.Ads.Lite",
         "frozen": true,
         "extraDependencies": "androidx.lifecycle.lifecycle-livedata-core,androidx.lifecycle.lifecycle-runtime",

--- a/source/com.google.android.gms/play-services-ads-api/PublicAPI/PublicAPI.Unshipped.txt
+++ b/source/com.google.android.gms/play-services-ads-api/PublicAPI/PublicAPI.Unshipped.txt
@@ -227,6 +227,17 @@ Google.Android.Gms.Ads.Initialization.IOnInitializationCompleteListener.OnInitia
 Google.Android.Gms.Ads.Initialization.InitializationCompleteEventArgs
 Google.Android.Gms.Ads.Initialization.InitializationCompleteEventArgs.InitializationCompleteEventArgs(Google.Android.Gms.Ads.Initialization.IInitializationStatus! p0) -> void
 Google.Android.Gms.Ads.Initialization.InitializationCompleteEventArgs.P0.get -> Google.Android.Gms.Ads.Initialization.IInitializationStatus!
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpDeepLinkServiceWrapper
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpDeepLinkServiceWrapper.EndSession(Android.Gms.Dynamic.IObjectWrapper! p0, string! p1) -> void
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpDeepLinkServiceWrapper.Open(Android.Gms.Dynamic.IObjectWrapper! p0, string! p1, string! p2, Android.OS.Bundle! p3, bool p4, Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpServiceCallback! p5) -> void
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpDeepLinkServiceWrapper.Prewarm(Android.Gms.Dynamic.IObjectWrapper! p0, System.Collections.Generic.IList<Android.OS.Bundle!>! p1, Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpPrewarmServiceCallback! p2) -> void
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpPrewarmServiceCallback
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpPrewarmServiceCallback.OnError(Android.OS.Bundle! p0) -> void
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpPrewarmServiceCallback.OnPrewarmCompleted(Android.OS.Bundle! p0) -> void
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpServiceCallback
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpServiceCallback.OnDismissed(Android.OS.Bundle! p0) -> void
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpServiceCallback.OnError(Android.OS.Bundle! p0) -> void
+Google.Android.Gms.Ads.Internal.Client.Hsdp.IHsdpServiceCallback.OnShown(Android.OS.Bundle! p0) -> void
 Google.Android.Gms.Ads.Internal.Offline.Buffering.OfflineNotificationPoster
 Google.Android.Gms.Ads.Internal.Offline.Buffering.OfflineNotificationPoster.OfflineNotificationPoster(Android.Content.Context! context, AndroidX.Work.WorkerParameters! params) -> void
 Google.Android.Gms.Ads.Internal.Offline.Buffering.OfflineNotificationPoster.OfflineNotificationPoster(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
@@ -1375,6 +1386,7 @@ virtual Google.Android.Gms.Ads.AdLoader.IsLoading.get -> bool
 virtual Google.Android.Gms.Ads.AdLoader.LoadAd(Google.Android.Gms.Ads.AdManager.AdManagerAdRequest! adManagerAdRequest) -> void
 virtual Google.Android.Gms.Ads.AdLoader.LoadAd(Google.Android.Gms.Ads.AdRequest! adRequest) -> void
 virtual Google.Android.Gms.Ads.AdLoader.LoadAds(Google.Android.Gms.Ads.AdRequest! adRequest, int maxNumberOfAds) -> void
+virtual Google.Android.Gms.Ads.AdManager.AdManagerInterstitialAdLoadCallback.OnAdLoaded(Google.Android.Gms.Ads.AdManager.AdManagerInterstitialAd! p0) -> void
 virtual Google.Android.Gms.Ads.AdRequest.AdString.get -> string?
 virtual Google.Android.Gms.Ads.AdRequest.Builder.Build() -> Google.Android.Gms.Ads.AdRequest!
 virtual Google.Android.Gms.Ads.AdRequest.Builder.Self() -> Google.Android.Gms.Ads.AdRequest.Builder!
@@ -1387,6 +1399,7 @@ virtual Google.Android.Gms.Ads.AdRequest.Keywords.get -> System.Collections.Gene
 virtual Google.Android.Gms.Ads.AdRequest.NeighboringContentUrls.get -> System.Collections.Generic.IList<string!>!
 virtual Google.Android.Gms.Ads.AdRequest.PlacementId.get -> long
 virtual Google.Android.Gms.Ads.AdRequest.RequestAgent.get -> string!
+virtual Google.Android.Gms.Ads.AppOpen.AppOpenAd.AppOpenAdLoadCallback.OnAdLoaded(Google.Android.Gms.Ads.AppOpen.AppOpenAd! p0) -> void
 virtual Google.Android.Gms.Ads.BaseAdView.AdListener.get -> Google.Android.Gms.Ads.AdListener!
 virtual Google.Android.Gms.Ads.BaseAdView.AdListener.set -> void
 virtual Google.Android.Gms.Ads.BaseAdView.AdSize.get -> Google.Android.Gms.Ads.AdSize?
@@ -1412,6 +1425,7 @@ virtual Google.Android.Gms.Ads.FullScreenContentCallback.OnAdDismissedFullScreen
 virtual Google.Android.Gms.Ads.FullScreenContentCallback.OnAdFailedToShowFullScreenContent(Google.Android.Gms.Ads.AdError! p0) -> void
 virtual Google.Android.Gms.Ads.FullScreenContentCallback.OnAdImpression() -> void
 virtual Google.Android.Gms.Ads.FullScreenContentCallback.OnAdShowedFullScreenContent() -> void
+virtual Google.Android.Gms.Ads.Interstitial.InterstitialAdLoadCallback.OnAdLoaded(Google.Android.Gms.Ads.Interstitial.InterstitialAd! p0) -> void
 virtual Google.Android.Gms.Ads.Mediation.Adapter.LoadAppOpenAd(Google.Android.Gms.Ads.Mediation.MediationAppOpenAdConfiguration! p0, Google.Android.Gms.Ads.Mediation.IMediationAdLoadCallback! callback) -> void
 virtual Google.Android.Gms.Ads.Mediation.Adapter.LoadBannerAd(Google.Android.Gms.Ads.Mediation.MediationBannerAdConfiguration! p0, Google.Android.Gms.Ads.Mediation.IMediationAdLoadCallback! callback) -> void
 virtual Google.Android.Gms.Ads.Mediation.Adapter.LoadInterstitialAd(Google.Android.Gms.Ads.Mediation.MediationInterstitialAdConfiguration! p0, Google.Android.Gms.Ads.Mediation.IMediationAdLoadCallback! callback) -> void
@@ -1503,8 +1517,10 @@ virtual Google.Android.Gms.Ads.RequestConfiguration.TagForChildDirectedTreatment
 virtual Google.Android.Gms.Ads.RequestConfiguration.TagForUnderAgeOfConsent.get -> int
 virtual Google.Android.Gms.Ads.RequestConfiguration.TestDeviceIds.get -> System.Collections.Generic.IList<string!>!
 virtual Google.Android.Gms.Ads.RequestConfiguration.ToBuilder() -> Google.Android.Gms.Ads.RequestConfiguration.Builder!
+virtual Google.Android.Gms.Ads.Rewarded.RewardedAdLoadCallback.OnAdLoaded(Google.Android.Gms.Ads.Rewarded.RewardedAd! p0) -> void
 virtual Google.Android.Gms.Ads.Rewarded.ServerSideVerificationOptions.CustomData.get -> string!
 virtual Google.Android.Gms.Ads.Rewarded.ServerSideVerificationOptions.UserId.get -> string!
+virtual Google.Android.Gms.Ads.RewardedInterstitial.RewardedInterstitialAdLoadCallback.OnAdLoaded(Google.Android.Gms.Ads.RewardedInterstitial.RewardedInterstitialAd! p0) -> void
 virtual Google.Android.Gms.Ads.VersionInfo.MajorVersion.get -> int
 virtual Google.Android.Gms.Ads.VersionInfo.MicroVersion.get -> int
 virtual Google.Android.Gms.Ads.VersionInfo.MinorVersion.get -> int

--- a/source/com.google.android.gms/play-services-ads-api/Transforms/Metadata.xml
+++ b/source/com.google.android.gms/play-services-ads-api/Transforms/Metadata.xml
@@ -125,4 +125,63 @@
 		OnAdFailedToLoadWithErrorCode
 	</attr>
 
+	<!--
+	  Java-generics erasure fix for AdLoadCallback<AdT> subclasses (issue #1491).
+
+	  The base class:
+	      public abstract class AdLoadCallback<AdT> {
+	          public void onAdLoaded(AdT ad) { }
+	      }
+	  only declares the erased onAdLoaded(Object) in bytecode, so the binding
+	  generator exposes it as `virtual OnAdLoaded(Java.Lang.Object p0)` on every
+	  concrete subclass (AdManagerInterstitialAdLoadCallback,
+	  InterstitialAdLoadCallback, etc.).
+
+	  When a user overrides that in C#, the generated Java ACW stub emits
+	  `public void onAdLoaded(java.lang.Object p0)`. From javac's point of view
+	  the parent (after generic substitution) declares
+	  `onAdLoaded(AdManagerInterstitialAd)`, and the two methods have the same
+	  erasure but neither overrides the other; javac reports a name-clash and
+	  the app fails to build.
+
+	  Fix: for each concrete subclass, add a specialized onAdLoaded(SpecificAd)
+	  method via add-node. That surfaces a properly-typed
+	  `virtual OnAdLoaded(SpecificAd p0)` in C# with a specialized JNI
+	  registration, so users' ACW stubs emit the specialized signature that
+	  correctly overrides the parent.
+
+	  Note: play-services-ads-lite also ships bindings for the same types
+	  (under the Android.Gms.Ads.* namespace); the equivalent fix lives in
+	  that project's Metadata.xml.
+	-->
+	<add-node path="/api/package[@name='com.google.android.gms.ads.admanager']/class[@name='AdManagerInterstitialAdLoadCallback']">
+		<method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/admanager/AdManagerInterstitialAd;)V" jni-return="V">
+			<parameter name="p0" type="com.google.android.gms.ads.admanager.AdManagerInterstitialAd" not-null="true"></parameter>
+		</method>
+	</add-node>
+
+	<add-node path="/api/package[@name='com.google.android.gms.ads.interstitial']/class[@name='InterstitialAdLoadCallback']">
+		<method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/interstitial/InterstitialAd;)V" jni-return="V">
+			<parameter name="p0" type="com.google.android.gms.ads.interstitial.InterstitialAd" not-null="true"></parameter>
+		</method>
+	</add-node>
+
+	<add-node path="/api/package[@name='com.google.android.gms.ads.rewarded']/class[@name='RewardedAdLoadCallback']">
+		<method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/rewarded/RewardedAd;)V" jni-return="V">
+			<parameter name="p0" type="com.google.android.gms.ads.rewarded.RewardedAd" not-null="true"></parameter>
+		</method>
+	</add-node>
+
+	<add-node path="/api/package[@name='com.google.android.gms.ads.rewardedinterstitial']/class[@name='RewardedInterstitialAdLoadCallback']">
+		<method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;)V" jni-return="V">
+			<parameter name="p0" type="com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd" not-null="true"></parameter>
+		</method>
+	</add-node>
+
+	<add-node path="/api/package[@name='com.google.android.gms.ads.appopen']/class[@name='AppOpenAd.AppOpenAdLoadCallback']">
+		<method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/appopen/AppOpenAd;)V" jni-return="V">
+			<parameter name="p0" type="com.google.android.gms.ads.appopen.AppOpenAd" not-null="true"></parameter>
+		</method>
+	</add-node>
+
 </metadata>

--- a/source/com.google.android.gms/play-services-ads-lite/PublicAPI/PublicAPI.Unshipped.txt
+++ b/source/com.google.android.gms/play-services-ads-lite/PublicAPI/PublicAPI.Unshipped.txt
@@ -1336,6 +1336,7 @@ virtual Android.Gms.Ads.AdLoader.IsLoading.get -> bool
 virtual Android.Gms.Ads.AdLoader.LoadAd(Android.Gms.Ads.AdManager.AdManagerAdRequest! adManagerAdRequest) -> void
 virtual Android.Gms.Ads.AdLoader.LoadAd(Android.Gms.Ads.AdRequest! adRequest) -> void
 virtual Android.Gms.Ads.AdLoader.LoadAds(Android.Gms.Ads.AdRequest! adRequest, int maxNumberOfAds) -> void
+virtual Android.Gms.Ads.AdManager.AdManagerInterstitialAdLoadCallback.OnAdLoaded(Android.Gms.Ads.AdManager.AdManagerInterstitialAd! p0) -> void
 virtual Android.Gms.Ads.AdRequest.AdString.get -> string?
 virtual Android.Gms.Ads.AdRequest.Builder.Build() -> Android.Gms.Ads.AdRequest!
 virtual Android.Gms.Ads.AdRequest.ContentUrl.get -> string!
@@ -1346,6 +1347,7 @@ virtual Android.Gms.Ads.AdRequest.IsTestDevice(Android.Content.Context! context)
 virtual Android.Gms.Ads.AdRequest.Keywords.get -> System.Collections.Generic.ICollection<string!>!
 virtual Android.Gms.Ads.AdRequest.NeighboringContentUrls.get -> System.Collections.Generic.IList<string!>!
 virtual Android.Gms.Ads.AdRequest.RequestAgent.get -> string!
+virtual Android.Gms.Ads.AppOpen.AppOpenAd.AppOpenAdLoadCallback.OnAdLoaded(Android.Gms.Ads.AppOpen.AppOpenAd! p0) -> void
 virtual Android.Gms.Ads.BaseAdView.AdListener.get -> Android.Gms.Ads.AdListener!
 virtual Android.Gms.Ads.BaseAdView.AdListener.set -> void
 virtual Android.Gms.Ads.BaseAdView.AdSize.get -> Android.Gms.Ads.AdSize?
@@ -1369,6 +1371,7 @@ virtual Android.Gms.Ads.FullScreenContentCallback.OnAdDismissedFullScreenContent
 virtual Android.Gms.Ads.FullScreenContentCallback.OnAdFailedToShowFullScreenContent(Android.Gms.Ads.AdError! p0) -> void
 virtual Android.Gms.Ads.FullScreenContentCallback.OnAdImpression() -> void
 virtual Android.Gms.Ads.FullScreenContentCallback.OnAdShowedFullScreenContent() -> void
+virtual Android.Gms.Ads.Interstitial.InterstitialAdLoadCallback.OnAdLoaded(Android.Gms.Ads.Interstitial.InterstitialAd! p0) -> void
 virtual Android.Gms.Ads.Mediation.Adapter.LoadAppOpenAd(Android.Gms.Ads.Mediation.MediationAppOpenAdConfiguration! p0, Android.Gms.Ads.Mediation.IMediationAdLoadCallback! callback) -> void
 virtual Android.Gms.Ads.Mediation.Adapter.LoadBannerAd(Android.Gms.Ads.Mediation.MediationBannerAdConfiguration! p0, Android.Gms.Ads.Mediation.IMediationAdLoadCallback! callback) -> void
 virtual Android.Gms.Ads.Mediation.Adapter.LoadInterstitialAd(Android.Gms.Ads.Mediation.MediationInterstitialAdConfiguration! p0, Android.Gms.Ads.Mediation.IMediationAdLoadCallback! callback) -> void
@@ -1454,8 +1457,10 @@ virtual Android.Gms.Ads.RequestConfiguration.TagForChildDirectedTreatment.get ->
 virtual Android.Gms.Ads.RequestConfiguration.TagForUnderAgeOfConsent.get -> int
 virtual Android.Gms.Ads.RequestConfiguration.TestDeviceIds.get -> System.Collections.Generic.IList<string!>!
 virtual Android.Gms.Ads.RequestConfiguration.ToBuilder() -> Android.Gms.Ads.RequestConfiguration.Builder!
+virtual Android.Gms.Ads.Rewarded.RewardedAdLoadCallback.OnAdLoaded(Android.Gms.Ads.Rewarded.RewardedAd! p0) -> void
 virtual Android.Gms.Ads.Rewarded.ServerSideVerificationOptions.CustomData.get -> string!
 virtual Android.Gms.Ads.Rewarded.ServerSideVerificationOptions.UserId.get -> string!
+virtual Android.Gms.Ads.RewardedInterstitial.RewardedInterstitialAdLoadCallback.OnAdLoaded(Android.Gms.Ads.RewardedInterstitial.RewardedInterstitialAd! p0) -> void
 virtual Android.Gms.Ads.VersionInfo.MajorVersion.get -> int
 virtual Android.Gms.Ads.VersionInfo.MicroVersion.get -> int
 virtual Android.Gms.Ads.VersionInfo.MinorVersion.get -> int

--- a/source/com.google.android.gms/play-services-ads-lite/Transforms/Metadata.xml
+++ b/source/com.google.android.gms/play-services-ads-lite/Transforms/Metadata.xml
@@ -127,6 +127,62 @@
             <parameter name="bundle" type="android.os.Bundle"></parameter>
         </method>
     </add-node>
+
+    <!--
+      Java-generics erasure fix for AdLoadCallback<AdT> subclasses (issue #1491).
+
+      The base class:
+          public abstract class AdLoadCallback<AdT> {
+              public void onAdLoaded(AdT ad) { }
+          }
+      only declares the erased `onAdLoaded(Object)` in bytecode, so the binding
+      generator exposes it as `virtual OnAdLoaded(Java.Lang.Object p0)` on every
+      concrete subclass (AdManagerInterstitialAdLoadCallback, InterstitialAdLoadCallback,
+      etc.).
+
+      When a user overrides that in C#, the generated Java ACW stub emits
+      `public void onAdLoaded(java.lang.Object p0)`. From javac's point of view
+      the parent (after generic substitution) declares
+      `onAdLoaded(AdManagerInterstitialAd)`, and the two methods have the same
+      erasure but neither overrides the other — javac reports a name-clash and
+      the app fails to build.
+
+      Fix: for each concrete subclass, add a specialized `onAdLoaded(SpecificAd)`
+      method via <add-node>. That surfaces a properly-typed
+      `virtual OnAdLoaded(SpecificAd p0)` in C# with a specialized JNI
+      registration, so users' ACW stubs emit the specialized signature that
+      correctly overrides the parent. This matches how Google's own docs show
+      the callback being overridden in Java.
+    -->
+    <add-node path="/api/package[@name='com.google.android.gms.ads.admanager']/class[@name='AdManagerInterstitialAdLoadCallback']">
+        <method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/admanager/AdManagerInterstitialAd;)V" jni-return="V">
+            <parameter name="p0" type="com.google.android.gms.ads.admanager.AdManagerInterstitialAd" not-null="true"></parameter>
+        </method>
+    </add-node>
+
+    <add-node path="/api/package[@name='com.google.android.gms.ads.interstitial']/class[@name='InterstitialAdLoadCallback']">
+        <method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/interstitial/InterstitialAd;)V" jni-return="V">
+            <parameter name="p0" type="com.google.android.gms.ads.interstitial.InterstitialAd" not-null="true"></parameter>
+        </method>
+    </add-node>
+
+    <add-node path="/api/package[@name='com.google.android.gms.ads.rewarded']/class[@name='RewardedAdLoadCallback']">
+        <method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/rewarded/RewardedAd;)V" jni-return="V">
+            <parameter name="p0" type="com.google.android.gms.ads.rewarded.RewardedAd" not-null="true"></parameter>
+        </method>
+    </add-node>
+
+    <add-node path="/api/package[@name='com.google.android.gms.ads.rewardedinterstitial']/class[@name='RewardedInterstitialAdLoadCallback']">
+        <method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/rewardedinterstitial/RewardedInterstitialAd;)V" jni-return="V">
+            <parameter name="p0" type="com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd" not-null="true"></parameter>
+        </method>
+    </add-node>
+
+    <add-node path="/api/package[@name='com.google.android.gms.ads.appopen']/class[@name='AppOpenAd.AppOpenAdLoadCallback']">
+        <method abstract="false" deprecated="not deprecated" final="false" name="onAdLoaded" native="false" return="void" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="(Lcom/google/android/gms/ads/appopen/AppOpenAd;)V" jni-return="V">
+            <parameter name="p0" type="com.google.android.gms.ads.appopen.AppOpenAd" not-null="true"></parameter>
+        </method>
+    </add-node>
     
     
     <attr


### PR DESCRIPTION
Fixes #1491.

## Problem

`AdLoadCallback<AdT>` declares `public void onAdLoaded(AdT ad)`, which erases to `onAdLoaded(Object)` in bytecode. The binding therefore only exposes `virtual OnAdLoaded(Java.Lang.Object p0)` on every concrete subclass:

- `AdManagerInterstitialAdLoadCallback`
- `InterstitialAdLoadCallback`
- `RewardedAdLoadCallback`
- `RewardedInterstitialAdLoadCallback`
- `AppOpenAd.AppOpenAdLoadCallback`

When a user overrides that in C#, the generated ACW Java stub emits `public void onAdLoaded(java.lang.Object p0)`, and javac rejects it:

```
error: name clash: onAdLoaded(Object) in MyCallback and
onAdLoaded(AdManagerInterstitialAd) in AdLoadCallback have the same
erasure, yet neither overrides the other
```

After generic substitution the parent's real method is the specialized one, so the erased override doesn't satisfy javac.

## Fix

For each concrete `*AdLoadCallback` subclass, add a specialized `onAdLoaded(SpecificAd)` method via `<add-node>` in the binding's `Transforms/Metadata.xml`. The binding now surfaces a properly-typed `virtual OnAdLoaded(SpecificAd)` with a specialized JNI registration, e.g.:

```csharp
[Register("onAdLoaded", "(Lcom/google/android/gms/ads/admanager/AdManagerInterstitialAd;)V",
          "GetOnAdLoaded_Lcom_google_android_gms_ads_admanager_AdManagerInterstitialAd_Handler")]
public virtual unsafe void OnAdLoaded(AdManagerInterstitialAd p0) { ... }
```

Users override the specialized overload, and the resulting ACW stub emits the specialized Java signature that correctly overrides the parent — matching how Google's docs show the callback being subclassed in Java.

The same fix is applied in **both** bindings that ship these types:

- `play-services-ads-lite` — `Android.Gms.Ads.*` namespace (used by `Xamarin.GooglePlayServices.Ads.Lite` direct consumers).
- `play-services-ads-api` — `Google.Android.Gms.Ads.*` namespace (pulled in transitively by `Xamarin.GooglePlayServices.Ads`, which is what the issue reporter uses).

Both `.aar`s independently contain the `*AdLoadCallback.class` files and each produces its own set of .NET types, so the metadata must be added in both places.

## Version bumps

- `Xamarin.GooglePlayServices.Ads.Lite`: `124.0.0.6` → `124.0.0.7`
- `Xamarin.GooglePlayServices.Ads.Api`: `125.4.0.1` → `125.4.0.2`
- `Xamarin.GooglePlayServices.Ads`:     `125.4.0.1` → `125.4.0.2`

## User-facing migration

Users hitting `javac.exe error JAVAC0000` from #1491 should change:

```csharp
public override void OnAdLoaded(Java.Lang.Object p0) { ... }
```

to the specialized overload, e.g.:

```csharp
public override void OnAdLoaded(AdManagerInterstitialAd p0) { ... }
```

## Verification

- `dotnet cake --target=metadata-verify` passes.
- Built both `com.google.android.gms.play-services-ads-lite` and `com.google.android.gms.play-services-ads-api` locally (against a project-referenced `Ads.Base` since the published `Ads.Base 124.0.0.1` NuGet does not yet target `net10.0-android36`) — build succeeded, 0 warnings, 0 errors.
- Verified generated `*AdLoadCallback.cs` in each project's `obj/` contains the specialized `virtual void OnAdLoaded(SpecificAd p0)` with the expected `[Register("onAdLoaded", "(Lcom/.../SpecificAd;)V", ...)]`.
- All 5 specialized overloads picked up in `PublicAPI.Unshipped.txt` for both packages by the analyzer.