### PR TITLE
Restore Change/StartTrackingTouch/StopTrackingTouch events on Slider and RangeSlider

### DIFF
--- a/config.json
+++ b/config.json
@@ -3518,7 +3518,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.14.0",
-        "nugetVersion": "1.14.0.4",
+        "nugetVersion": "1.14.0.5",
         "nugetId": "Xamarin.Google.Android.Material",
         "comments": "Requires API-34"
       },

--- a/source/com.google.android.material/material/Additions/SliderListenerMethods.cs
+++ b/source/com.google.android.material/material/Additions/SliderListenerMethods.cs
@@ -76,6 +76,61 @@ public partial class Slider
             GC.KeepAlive(listener);
         }
     }
+
+    // C# events wrapping the listener pattern — equivalent to the auto-generated events
+    // that the binding generator no longer produces because addOnChangeListener /
+    // addOnSliderTouchListener are removed from the generated API (remove-node in Metadata.xml)
+    // and re-added via this Additions file instead.
+
+    WeakReference? _weak_implementor_AddOnChangeListener;
+    Slider.IOnChangeListenerImplementor __CreateIOnChangeListenerImplementor()
+        => new Slider.IOnChangeListenerImplementor(this);
+
+    public event EventHandler<Slider.ChangeEventArgs> Change
+    {
+        add => Java.Interop.EventHelper.AddEventHandler<Slider.IOnChangeListener, Slider.IOnChangeListenerImplementor>(
+            ref _weak_implementor_AddOnChangeListener,
+            __CreateIOnChangeListenerImplementor,
+            AddOnChangeListener,
+            __h => __h.Handler += value);
+        remove => Java.Interop.EventHelper.RemoveEventHandler<Slider.IOnChangeListener, Slider.IOnChangeListenerImplementor>(
+            ref _weak_implementor_AddOnChangeListener,
+            Slider.IOnChangeListenerImplementor.__IsEmpty,
+            __v => RemoveOnChangeListener(__v),
+            __h => __h.Handler -= value);
+    }
+
+    WeakReference? _weak_implementor_AddOnSliderTouchListener;
+    Slider.IOnSliderTouchListenerImplementor __CreateIOnSliderTouchListenerImplementor()
+        => new Slider.IOnSliderTouchListenerImplementor(this);
+
+    public event EventHandler<Slider.StartTrackingTouchEventArgs> StartTrackingTouch
+    {
+        add => Java.Interop.EventHelper.AddEventHandler<Slider.IOnSliderTouchListener, Slider.IOnSliderTouchListenerImplementor>(
+            ref _weak_implementor_AddOnSliderTouchListener,
+            __CreateIOnSliderTouchListenerImplementor,
+            AddOnSliderTouchListener,
+            __h => __h.OnStartTrackingTouchHandler += value);
+        remove => Java.Interop.EventHelper.RemoveEventHandler<Slider.IOnSliderTouchListener, Slider.IOnSliderTouchListenerImplementor>(
+            ref _weak_implementor_AddOnSliderTouchListener,
+            Slider.IOnSliderTouchListenerImplementor.__IsEmpty,
+            __v => RemoveOnSliderTouchListener(__v),
+            __h => __h.OnStartTrackingTouchHandler -= value);
+    }
+
+    public event EventHandler<Slider.StopTrackingTouchEventArgs> StopTrackingTouch
+    {
+        add => Java.Interop.EventHelper.AddEventHandler<Slider.IOnSliderTouchListener, Slider.IOnSliderTouchListenerImplementor>(
+            ref _weak_implementor_AddOnSliderTouchListener,
+            __CreateIOnSliderTouchListenerImplementor,
+            AddOnSliderTouchListener,
+            __h => __h.OnStopTrackingTouchHandler += value);
+        remove => Java.Interop.EventHelper.RemoveEventHandler<Slider.IOnSliderTouchListener, Slider.IOnSliderTouchListenerImplementor>(
+            ref _weak_implementor_AddOnSliderTouchListener,
+            Slider.IOnSliderTouchListenerImplementor.__IsEmpty,
+            __v => RemoveOnSliderTouchListener(__v),
+            __h => __h.OnStopTrackingTouchHandler -= value);
+    }
 }
 
 public partial class RangeSlider
@@ -143,6 +198,56 @@ public partial class RangeSlider
         {
             GC.KeepAlive(listener);
         }
+    }
+
+    WeakReference? _weak_implementor_AddOnChangeListener;
+    RangeSlider.IOnChangeListenerImplementor __CreateIOnChangeListenerImplementor()
+        => new RangeSlider.IOnChangeListenerImplementor(this);
+
+    public event EventHandler<RangeSlider.ChangeEventArgs> Change
+    {
+        add => Java.Interop.EventHelper.AddEventHandler<RangeSlider.IOnChangeListener, RangeSlider.IOnChangeListenerImplementor>(
+            ref _weak_implementor_AddOnChangeListener,
+            __CreateIOnChangeListenerImplementor,
+            AddOnChangeListener,
+            __h => __h.Handler += value);
+        remove => Java.Interop.EventHelper.RemoveEventHandler<RangeSlider.IOnChangeListener, RangeSlider.IOnChangeListenerImplementor>(
+            ref _weak_implementor_AddOnChangeListener,
+            RangeSlider.IOnChangeListenerImplementor.__IsEmpty,
+            __v => RemoveOnChangeListener(__v),
+            __h => __h.Handler -= value);
+    }
+
+    WeakReference? _weak_implementor_AddOnSliderTouchListener;
+    RangeSlider.IOnSliderTouchListenerImplementor __CreateIOnSliderTouchListenerImplementor()
+        => new RangeSlider.IOnSliderTouchListenerImplementor(this);
+
+    public event EventHandler<RangeSlider.StartTrackingTouchEventArgs> StartTrackingTouch
+    {
+        add => Java.Interop.EventHelper.AddEventHandler<RangeSlider.IOnSliderTouchListener, RangeSlider.IOnSliderTouchListenerImplementor>(
+            ref _weak_implementor_AddOnSliderTouchListener,
+            __CreateIOnSliderTouchListenerImplementor,
+            AddOnSliderTouchListener,
+            __h => __h.OnStartTrackingTouchHandler += value);
+        remove => Java.Interop.EventHelper.RemoveEventHandler<RangeSlider.IOnSliderTouchListener, RangeSlider.IOnSliderTouchListenerImplementor>(
+            ref _weak_implementor_AddOnSliderTouchListener,
+            RangeSlider.IOnSliderTouchListenerImplementor.__IsEmpty,
+            __v => RemoveOnSliderTouchListener(__v),
+            __h => __h.OnStartTrackingTouchHandler -= value);
+    }
+
+    public event EventHandler<RangeSlider.StopTrackingTouchEventArgs> StopTrackingTouch
+    {
+        add => Java.Interop.EventHelper.AddEventHandler<RangeSlider.IOnSliderTouchListener, RangeSlider.IOnSliderTouchListenerImplementor>(
+            ref _weak_implementor_AddOnSliderTouchListener,
+            __CreateIOnSliderTouchListenerImplementor,
+            AddOnSliderTouchListener,
+            __h => __h.OnStopTrackingTouchHandler += value);
+        remove => Java.Interop.EventHelper.RemoveEventHandler<RangeSlider.IOnSliderTouchListener, RangeSlider.IOnSliderTouchListenerImplementor>(
+            ref _weak_implementor_AddOnSliderTouchListener,
+            RangeSlider.IOnSliderTouchListenerImplementor.__IsEmpty,
+            __v => RemoveOnSliderTouchListener(__v),
+            __h => __h.OnStopTrackingTouchHandler -= value);
     }
 }
 

--- a/source/com.google.android.material/material/PublicAPI/PublicAPI.Unshipped.txt
+++ b/source/com.google.android.material/material/PublicAPI/PublicAPI.Unshipped.txt
@@ -1991,6 +1991,7 @@ Google.Android.Material.Slider.LabelFormatterConsts
 Google.Android.Material.Slider.RangeSlider
 Google.Android.Material.Slider.RangeSlider.AddOnChangeListener(Google.Android.Material.Slider.RangeSlider.IOnChangeListener! listener) -> void
 Google.Android.Material.Slider.RangeSlider.AddOnSliderTouchListener(Google.Android.Material.Slider.RangeSlider.IOnSliderTouchListener! listener) -> void
+Google.Android.Material.Slider.RangeSlider.Change -> System.EventHandler<Google.Android.Material.Slider.RangeSlider.ChangeEventArgs!>!
 Google.Android.Material.Slider.RangeSlider.ChangeEventArgs
 Google.Android.Material.Slider.RangeSlider.ChangeEventArgs.ChangeEventArgs(Google.Android.Material.Slider.RangeSlider! p0, float p1, bool p2) -> void
 Google.Android.Material.Slider.RangeSlider.ChangeEventArgs.P0.get -> Google.Android.Material.Slider.RangeSlider!
@@ -2007,15 +2008,18 @@ Google.Android.Material.Slider.RangeSlider.RangeSlider(Android.Content.Context! 
 Google.Android.Material.Slider.RangeSlider.RangeSlider(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
 Google.Android.Material.Slider.RangeSlider.RemoveOnChangeListener(Google.Android.Material.Slider.RangeSlider.IOnChangeListener! listener) -> void
 Google.Android.Material.Slider.RangeSlider.RemoveOnSliderTouchListener(Google.Android.Material.Slider.RangeSlider.IOnSliderTouchListener! listener) -> void
+Google.Android.Material.Slider.RangeSlider.StartTrackingTouch -> System.EventHandler<Google.Android.Material.Slider.RangeSlider.StartTrackingTouchEventArgs!>!
 Google.Android.Material.Slider.RangeSlider.StartTrackingTouchEventArgs
 Google.Android.Material.Slider.RangeSlider.StartTrackingTouchEventArgs.P0.get -> Google.Android.Material.Slider.RangeSlider!
 Google.Android.Material.Slider.RangeSlider.StartTrackingTouchEventArgs.StartTrackingTouchEventArgs(Google.Android.Material.Slider.RangeSlider! p0) -> void
+Google.Android.Material.Slider.RangeSlider.StopTrackingTouch -> System.EventHandler<Google.Android.Material.Slider.RangeSlider.StopTrackingTouchEventArgs!>!
 Google.Android.Material.Slider.RangeSlider.StopTrackingTouchEventArgs
 Google.Android.Material.Slider.RangeSlider.StopTrackingTouchEventArgs.P0.get -> Google.Android.Material.Slider.RangeSlider!
 Google.Android.Material.Slider.RangeSlider.StopTrackingTouchEventArgs.StopTrackingTouchEventArgs(Google.Android.Material.Slider.RangeSlider! p0) -> void
 Google.Android.Material.Slider.Slider
 Google.Android.Material.Slider.Slider.AddOnChangeListener(Google.Android.Material.Slider.Slider.IOnChangeListener! listener) -> void
 Google.Android.Material.Slider.Slider.AddOnSliderTouchListener(Google.Android.Material.Slider.Slider.IOnSliderTouchListener! listener) -> void
+Google.Android.Material.Slider.Slider.Change -> System.EventHandler<Google.Android.Material.Slider.Slider.ChangeEventArgs!>!
 Google.Android.Material.Slider.Slider.ChangeEventArgs
 Google.Android.Material.Slider.Slider.ChangeEventArgs.ChangeEventArgs(Google.Android.Material.Slider.Slider! p0, float p1, bool p2) -> void
 Google.Android.Material.Slider.Slider.ChangeEventArgs.P0.get -> Google.Android.Material.Slider.Slider!
@@ -2033,9 +2037,11 @@ Google.Android.Material.Slider.Slider.Slider(Android.Content.Context! context) -
 Google.Android.Material.Slider.Slider.Slider(Android.Content.Context! context, Android.Util.IAttributeSet? attrs) -> void
 Google.Android.Material.Slider.Slider.Slider(Android.Content.Context! context, Android.Util.IAttributeSet? attrs, int defStyleAttr) -> void
 Google.Android.Material.Slider.Slider.Slider(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Google.Android.Material.Slider.Slider.StartTrackingTouch -> System.EventHandler<Google.Android.Material.Slider.Slider.StartTrackingTouchEventArgs!>!
 Google.Android.Material.Slider.Slider.StartTrackingTouchEventArgs
 Google.Android.Material.Slider.Slider.StartTrackingTouchEventArgs.P0.get -> Google.Android.Material.Slider.Slider!
 Google.Android.Material.Slider.Slider.StartTrackingTouchEventArgs.StartTrackingTouchEventArgs(Google.Android.Material.Slider.Slider! p0) -> void
+Google.Android.Material.Slider.Slider.StopTrackingTouch -> System.EventHandler<Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs!>!
 Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs
 Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs.P0.get -> Google.Android.Material.Slider.Slider!
 Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs.StopTrackingTouchEventArgs(Google.Android.Material.Slider.Slider! p0) -> void


### PR DESCRIPTION
## Problem

PR #1486 fixed the ACW implementor build failure (#1484) by removing the auto-generated `addOnChangeListener`/`addOnSliderTouchListener` methods from `BaseSlider` via `remove-node` in Metadata.xml and re-adding them as hand-written Additions.

However, the binding generator only produces C# events (`Change`, `StartTrackingTouch`, `StopTrackingTouch`) for methods it sees in the **generated API XML**. Since those methods were removed from the generated API, the events were no longer emitted — causing a regression in `1.14.0.4`:

```
error CS1061: 'Slider' does not contain a definition for 'Change'
```

Reported by a user in: https://github.com/dotnet/android-libraries/issues/1484#issuecomment-4859989353

## Fix

Add the three C# events manually to `SliderListenerMethods.cs` for both `Slider` and `RangeSlider`:

- `Change` — wraps `AddOnChangeListener`/`RemoveOnChangeListener`
- `StartTrackingTouch` — wraps `AddOnSliderTouchListener`/`RemoveOnSliderTouchListener`
- `StopTrackingTouch` — wraps `AddOnSliderTouchListener`/`RemoveOnSliderTouchListener`

Each event uses `Java.Interop.EventHelper.AddEventHandler/RemoveEventHandler` with the already-generated implementor types (`IOnChangeListenerImplementor`, `IOnSliderTouchListenerImplementor`). This is exactly what the generator would have produced had the methods remained in the generated API.

## EventArgs type change (improvement)

The old `ChangeEventArgs.P0` was `Java.Lang.Object` (because `BaseOnChangeListener<S>` used a generic that erased to `Object`). The new `ChangeEventArgs.P0` is the concrete `Slider` or `RangeSlider` type — a typed improvement. `P1` (`float`) and `P2` (`bool`) are unchanged.

## NuGet version

`Xamarin.Google.Android.Material`: `1.14.0.4` → `1.14.0.5`

Fixes #1484