### PR TITLE
Fix R8 stripping BaseOnChangeListener/BaseOnSliderTouchListener in Release builds

### DIFF
--- a/config.json
+++ b/config.json
@@ -3518,7 +3518,7 @@
         "groupId": "com.google.android.material",
         "artifactId": "material",
         "version": "1.14.0",
-        "nugetVersion": "1.14.0.5",
+        "nugetVersion": "1.14.0.6",
         "nugetId": "Xamarin.Google.Android.Material",
         "comments": "Requires API-34"
       },

--- a/source/com.google.android.material/material/PublicAPI/PublicAPI.Unshipped.txt
+++ b/source/com.google.android.material/material/PublicAPI/PublicAPI.Unshipped.txt
@@ -1978,10 +1978,20 @@ Google.Android.Material.SideSheet.SideSheetDialog
 Google.Android.Material.SideSheet.SideSheetDialog.SideSheetDialog(Android.Content.Context! context) -> void
 Google.Android.Material.SideSheet.SideSheetDialog.SideSheetDialog(Android.Content.Context! context, int theme) -> void
 Google.Android.Material.SideSheet.SideSheetDialog.SideSheetDialog(nint javaReference, Android.Runtime.JniHandleOwnership transfer) -> void
+Google.Android.Material.Slider.BaseOnChangeEventArgs
+Google.Android.Material.Slider.BaseOnChangeEventArgs.BaseOnChangeEventArgs(Java.Lang.Object! p0, float p1, bool p2) -> void
+Google.Android.Material.Slider.BaseOnChangeEventArgs.P0.get -> Java.Lang.Object!
+Google.Android.Material.Slider.BaseOnChangeEventArgs.P1.get -> float
+Google.Android.Material.Slider.BaseOnChangeEventArgs.P2.get -> bool
 Google.Android.Material.Slider.BasicLabelFormatter
 Google.Android.Material.Slider.BasicLabelFormatter.BasicLabelFormatter() -> void
 Google.Android.Material.Slider.BasicLabelFormatter.GetFormattedValue(float value) -> string!
 Google.Android.Material.Slider.BasicLabelFormatter.InterfaceConsts
+Google.Android.Material.Slider.IBaseOnChangeListener
+Google.Android.Material.Slider.IBaseOnChangeListener.OnValueChange(Java.Lang.Object! p0, float p1, bool p2) -> void
+Google.Android.Material.Slider.IBaseOnSliderTouchListener
+Google.Android.Material.Slider.IBaseOnSliderTouchListener.OnStartTrackingTouch(Java.Lang.Object! p0) -> void
+Google.Android.Material.Slider.IBaseOnSliderTouchListener.OnStopTrackingTouch(Java.Lang.Object! p0) -> void
 Google.Android.Material.Slider.ILabelFormatter
 Google.Android.Material.Slider.ILabelFormatter.GetFormattedValue(float p0) -> string!
 Google.Android.Material.Slider.ISliderOrientation
@@ -2047,6 +2057,12 @@ Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs.P0.get -> Googl
 Google.Android.Material.Slider.Slider.StopTrackingTouchEventArgs.StopTrackingTouchEventArgs(Google.Android.Material.Slider.Slider! p0) -> void
 Google.Android.Material.Slider.SliderOrientation
 Google.Android.Material.Slider.SliderOrientationConsts
+Google.Android.Material.Slider.StartTrackingTouchEventArgs
+Google.Android.Material.Slider.StartTrackingTouchEventArgs.P0.get -> Java.Lang.Object!
+Google.Android.Material.Slider.StartTrackingTouchEventArgs.StartTrackingTouchEventArgs(Java.Lang.Object! p0) -> void
+Google.Android.Material.Slider.StopTrackingTouchEventArgs
+Google.Android.Material.Slider.StopTrackingTouchEventArgs.P0.get -> Java.Lang.Object!
+Google.Android.Material.Slider.StopTrackingTouchEventArgs.StopTrackingTouchEventArgs(Java.Lang.Object! p0) -> void
 Google.Android.Material.Slider.TickVisibilityMode
 Google.Android.Material.Slider.TickVisibilityModeAttribute
 Google.Android.Material.Slider.TickVisibilityModeAttribute.TickVisibilityModeAttribute() -> void

--- a/source/com.google.android.material/material/Transforms/Metadata.xml
+++ b/source/com.google.android.material/material/Transforms/Metadata.xml
@@ -319,35 +319,55 @@
       com.google.android.material.appbar.AppBarLayout
     </attr>
 
-    <!-- Remove deprecated BaseOnChangeListener and BaseOnSliderTouchListener interfaces entirely.
-         These base interfaces use erased generics that cause ACW type erasure clashes when
-         implemented alongside their typed sub-interfaces (Slider.OnChangeListener, etc.).
-         The binding generator creates Implementor Java classes for any interface referenced in
-         add/removeListener pairs, but these implementors cannot satisfy the Java abstract method
-         contracts because of the erasure. Removing the base interfaces eliminates the
-         implementor generation (no interface type → no implementor). -->
-    <remove-node
-      path="/api/package[@name='com.google.android.material.slider']/interface[@name='BaseOnChangeListener']" />
-    <remove-node
-      path="/api/package[@name='com.google.android.material.slider']/interface[@name='BaseOnSliderTouchListener']" />
+    <!-- Fix BaseSlider addOnChangeListener and removeOnChangeListener methods -->
+    <attr
+      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='addOnChangeListener' and count(parameter)=1 and parameter[1][@type='L']]/parameter[1]"
+      name="type"
+      >
+      com.google.android.material.slider.BaseOnChangeListener
+    </attr>
+    <attr
+      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='removeOnChangeListener' and count(parameter)=1 and parameter[1][@type='L']]/parameter[1]"
+      name="type"
+      >
+      com.google.android.material.slider.BaseOnChangeListener
+    </attr>
+    
+    <!-- Fix BaseSlider addOnSliderTouchListener and removeOnSliderTouchListener methods -->
+    <attr
+      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='addOnSliderTouchListener' and count(parameter)=1 and parameter[1][@type='T']]/parameter[1]"
+      name="type"
+      >
+      com.google.android.material.slider.BaseOnSliderTouchListener
+    </attr>
+    <attr
+      path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='removeOnSliderTouchListener' and count(parameter)=1 and parameter[1][@type='T']]/parameter[1]"
+      name="type"
+      >
+      com.google.android.material.slider.BaseOnSliderTouchListener
+    </attr>
 
-    <!-- Remove the 'implements BaseOnChangeListener/BaseOnSliderTouchListener' from the typed
-         sub-interfaces so they don't reference the now-removed base types.
-         This makes them standalone interfaces with just their typed methods. -->
+    <!-- Break the implements chain from typed sub-interfaces to the @RestrictTo base interfaces.
+         This prevents ACW erasure clash when users implement Slider.IOnChangeListener or
+         Slider.IOnSliderTouchListener — without this, the ACW generates both onValueChange(Object)
+         and onValueChange(Slider), which have the same Java erasure. (#1482)
+         The base interfaces and their methods remain intact, so the Implementor ACWs compile
+         and their Java references keep the types alive for R8. -->
     <remove-node
       path="/api/package[@name='com.google.android.material.slider']/interface[@name='Slider.OnChangeListener']/implements[@name='com.google.android.material.slider.BaseOnChangeListener']" />
     <remove-node
-      path="/api/package[@name='com.google.android.material.slider']/interface[@name='Slider.OnSliderTouchListener']/implements[@name='com.google.android.material.slider.BaseOnSliderTouchListener']" />
-    <remove-node
       path="/api/package[@name='com.google.android.material.slider']/interface[@name='RangeSlider.OnChangeListener']/implements[@name='com.google.android.material.slider.BaseOnChangeListener']" />
+    <remove-node
+      path="/api/package[@name='com.google.android.material.slider']/interface[@name='Slider.OnSliderTouchListener']/implements[@name='com.google.android.material.slider.BaseOnSliderTouchListener']" />
     <remove-node
       path="/api/package[@name='com.google.android.material.slider']/interface[@name='RangeSlider.OnSliderTouchListener']/implements[@name='com.google.android.material.slider.BaseOnSliderTouchListener']" />
 
-    <!-- Remove the add/remove listener methods from BaseSlider to prevent implementor generation.
-         These methods reference the removed base interfaces as parameter types. We re-implement
-         them manually in Additions with typed overloads (Slider.IOnChangeListener, etc.) that
-         use the correct JNI signatures. This is a standard binding pattern: remove problematic
-         auto-generated method, replace with hand-written Additions code. -->
+    <!-- Remove the auto-generated add/remove listener methods from BaseSlider (which accept
+         IBaseOnChangeListener/IBaseOnSliderTouchListener) and re-add them via hand-written
+         Additions with typed params (Slider.IOnChangeListener etc.) for the Android-recommended API.
+         Keeping the base interfaces intact ensures their Implementor ACWs generate Java code that
+         references BaseOnChangeListener/BaseOnSliderTouchListener, preventing R8 from stripping
+         the types at link time. -->
     <remove-node
       path="/api/package[@name='com.google.android.material.slider']/class[@name='BaseSlider']/method[@name='addOnChangeListener']" />
     <remove-node


### PR DESCRIPTION
## Problem

In Release builds with R8 enabled, apps using Material Slider crash with `NoSuchMethodError` because R8 strips `BaseOnChangeListener` and `BaseOnSliderTouchListener` types — no Java code references them after PR #1486 removed the interfaces entirely.

Fixes #1501

## Fix

Instead of removing `IBaseOnChangeListener` and `IBaseOnSliderTouchListener` entirely, keep them intact with their methods. This causes the binding generator to produce Implementor ACW classes containing `implements BaseOnChangeListener` in Java — giving R8 a traceable reference that prevents stripping.

To avoid the erasure clash (#1482), the `implements` chain from typed sub-interfaces (`Slider.OnChangeListener`, `RangeSlider.OnChangeListener`, etc.) to the base interfaces is broken via `remove-node` in Metadata.xml.

The auto-generated `addOnChangeListener`/`removeOnChangeListener` methods on `BaseSlider` are removed and replaced with hand-written typed overloads in Additions that accept `Slider.IOnChangeListener` (the Android-recommended API) while using the correct erased JNI signature internally.

## Changes

- **`Metadata.xml`**: Reverted removal of base interfaces; added `remove-node` for implements chain and auto-generated add/remove methods on BaseSlider
- **`config.json`**: Bumped nugetVersion to 1.14.0.6
- **`PublicAPI.Unshipped.txt`**: Regenerated to reflect restored base interfaces
