### PR TITLE
[Xamarin.Build.Download] Prevent interactive 7-Zip extraction hangs

### DIFF
--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Reflection;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Build.Construction;
@@ -155,6 +156,25 @@ namespace NativeLibraryDownloaderTests
 			Assert.True (success);
 
 			Assert.True (File.Exists (Path.Combine (unpackDir, "GoogleSymbolUtilities-1.0.3", "Libraries", "libGSDK_Overload.a")));
+		}
+
+		[Fact]
+		public void Test7ZipExtractionIsNonInteractive ()
+		{
+			var method = typeof (Xamarin.Build.Download.XamarinDownloadArchives).GetMethod (
+				"Build7ZipExtractionArgs",
+				BindingFlags.NonPublic | BindingFlags.Static);
+			var sevenZipPath = Path.GetTempFileName ();
+
+			var args = method.Invoke (null, new object [] {
+				"archive.tgz",
+				TempDir,
+				sevenZipPath,
+				false,
+				null,
+			});
+
+			Assert.Contains ("-y", args.ToString ());
 		}
 
 		[Fact]

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
@@ -164,7 +164,9 @@ namespace NativeLibraryDownloaderTests
 			var method = typeof (Xamarin.Build.Download.XamarinDownloadArchives).GetMethod (
 				"Build7ZipExtractionArgs",
 				BindingFlags.NonPublic | BindingFlags.Static);
-			var sevenZipPath = Path.GetTempFileName ();
+			Assert.True (method != null, "Could not find XamarinDownloadArchives.Build7ZipExtractionArgs via reflection.");
+			var sevenZipPath = Path.Combine (TempDir, "7z.exe");
+			File.WriteAllText (sevenZipPath, string.Empty);
 
 			var args = method.Invoke (null, new object [] {
 				"archive.tgz",

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -9,7 +9,7 @@
 
     <PackageId>Xamarin.Build.Download</PackageId>
     <Title>Xamarin Build-time Download Support</Title>
-    <PackageVersion>0.11.4</PackageVersion>
+    <PackageVersion>0.11.5</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865061</PackageProjectUrl>

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
@@ -319,6 +319,9 @@ namespace Xamarin.Build.Download
 			if (ignoreTarSymLinks)
 				args.Add ("-snl-");
 
+			// Never let 7-Zip wait for input from a non-interactive MSBuild task.
+			// https://7-zip.opensource.jp/chm/cmdline/switches/yes.htm
+			args.Add ("-y");
 			args.AddQuoted ("-o" + contentDir);
 			args.AddQuoted (file);
 			return args;


### PR DESCRIPTION
## Changes

- Pass 7-Zip's [`-y` switch](https://7-zip.opensource.jp/chm/cmdline/switches/yes.htm) so extraction cannot wait indefinitely for overwrite confirmation.
- Add regression coverage for non-interactive extraction arguments.
- Bump Xamarin.Build.Download from 0.11.4 to 0.11.5.

Fixes #1047