### PR TITLE
Use GPT-5.6 Sol for weekly stable updates

### DIFF
--- a/.github/workflows/weekly-stable-updates.yml
+++ b/.github/workflows/weekly-stable-updates.yml
@@ -86,7 +86,7 @@ jobs:
           --input - <<< '{
           "assignees": ["copilot-swe-agent[bot]"],
           "agent_assignment": {
-            "model": "claude-opus-4.8"
+            "model": "gpt-5.6-sol"
           }
         }'
       env:


### PR DESCRIPTION
Updates the Copilot agent assignment in the weekly stable updates workflow to use `gpt-5.6-sol` instead of Claude Opus 4.8.