### PR TITLE
Use dotnet-public feed for CI workloads

### DIFF
--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -32,6 +32,25 @@ steps:
           Write-Host "##vso[task.complete result=Failed;]"
           exit 0
       }
+
+      $workloadList = dotnet workload list
+      $androidMatch = [regex]::Match(
+          ($workloadList -join "`n"),
+          '(?m)^\s*android\s+([^/\s]+)'
+      )
+      $androidVersion = $null
+      if (
+          !$androidMatch.Success -or
+          ![System.Management.Automation.SemanticVersion]::TryParse(
+              $androidMatch.Groups[1].Value,
+              [ref]$androidVersion
+          ) -or
+          $androidVersion -lt [System.Management.Automation.SemanticVersion]'36.1.69'
+      ) {
+          Write-Host "##vso[task.logissue type=error]Android workload version must be 36.1.69 or newer."
+          Write-Host "##vso[task.complete result=Failed;]"
+          exit 0
+      }
     displayName: Install .NET Workloads
 
   - template: install-java.yml

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -26,7 +26,6 @@ steps:
     ignoreLASTEXITCODE: true
 
   - pwsh: |    
-      dotnet workload update --verbosity diag --source $(dotnetWorkloadSource)
       dotnet workload install maui-android android --verbosity diag --source $(dotnetWorkloadSource)
       if ($LASTEXITCODE -ne 0) {
           Write-Host "##vso[task.logissue type=error]Failed to install workloads."
@@ -95,4 +94,3 @@ steps:
     displayName: Clean Android SDK package.xml files
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     continueOnError: true
-

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -26,8 +26,8 @@ steps:
     ignoreLASTEXITCODE: true
 
   - pwsh: |    
-      dotnet workload update --verbosity diag --source https://api.nuget.org/v3/index.json
-      dotnet workload install maui-android android --verbosity diag --source https://api.nuget.org/v3/index.json
+      dotnet workload update --verbosity diag --source $(dotnetWorkloadSource)
+      dotnet workload install maui-android android --verbosity diag --source $(dotnetWorkloadSource)
       if ($LASTEXITCODE -ne 0) {
           Write-Host "##vso[task.logissue type=error]Failed to install workloads."
           Write-Host "##vso[task.complete result=Failed;]"
@@ -95,5 +95,4 @@ steps:
     displayName: Clean Android SDK package.xml files
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     continueOnError: true
-
 

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -21,8 +21,7 @@ variables:
   # Tool variables
   dotnetVersion: '10.x'                                                                 # .NET version to install on agent
   dotnetFrameworkVersion: 9                                                             # The number to use for TF (eg: netX.0-android)
-  dotnetWorkloadSource: >-                                                              # NuGet source for workloads
-    https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
+  dotnetWorkloadSource: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json' # NuGet source for workloads
 
   # Standard test variables
   standardTestProject: tests/allpackages/AllPackagesTests.csproj                                                      # Standard tests project file

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -21,7 +21,7 @@ variables:
   # Tool variables
   dotnetVersion: '10.x'                                                                 # .NET version to install on agent
   dotnetFrameworkVersion: 9                                                             # The number to use for TF (eg: netX.0-android)
-  dotnetNuGetOrgSource: 'https://api.nuget.org/v3/index.json'                           # NuGet.org URL to find workloads
+  dotnetWorkloadSource: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json' # NuGet source for workloads
 
   # Standard test variables
   standardTestProject: tests/allpackages/AllPackagesTests.csproj                                                      # Standard tests project file

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -21,7 +21,8 @@ variables:
   # Tool variables
   dotnetVersion: '10.x'                                                                 # .NET version to install on agent
   dotnetFrameworkVersion: 9                                                             # The number to use for TF (eg: netX.0-android)
-  dotnetWorkloadSource: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json' # NuGet source for workloads
+  # NuGet source for workloads
+  dotnetWorkloadSource: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json'
 
   # Standard test variables
   standardTestProject: tests/allpackages/AllPackagesTests.csproj                                                      # Standard tests project file

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -21,8 +21,8 @@ variables:
   # Tool variables
   dotnetVersion: '10.x'                                                                 # .NET version to install on agent
   dotnetFrameworkVersion: 9                                                             # The number to use for TF (eg: netX.0-android)
-  # NuGet source for workloads
-  dotnetWorkloadSource: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json'
+  dotnetWorkloadSource: >-                                                              # NuGet source for workloads
+    https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
 
   # Standard test variables
   standardTestProject: tests/allpackages/AllPackagesTests.csproj                                                      # Standard tests project file


### PR DESCRIPTION
Azure DevOps workload installation currently reaches api.nuget.org, causing CFSClean network-isolation violations.

Define the dnceng `dotnet-public` feed as the shared workload source and use it for both `dotnet workload update` and `dotnet workload install`.