### PR TITLE
[ci] Route Maven traffic through dotnet-public-maven

### DIFF
--- a/build/ci/build-and-test.yml
+++ b/build/ci/build-and-test.yml
@@ -16,6 +16,7 @@ steps:
     displayName: 'Build packages'
     env:
       JavaSdkDirectory: $(JAVA_HOME)
+      RUNNINGONCI: true
       RepositoryCommit: $(Build.SourceVersion)
       RepositoryBranch: $(Build.SourceBranchName)
       RepositoryUrl: $(Build.Repository.Uri)

--- a/build/gradle/mirror-dependencies.ps1
+++ b/build/gradle/mirror-dependencies.ps1
@@ -1,0 +1,121 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Seeds Maven dependencies into the dnceng dotnet-public-maven feed.
+
+.DESCRIPTION
+    CI reads the feed anonymously. New upstream artifacts return 401 until an
+    authenticated developer request causes Azure Artifacts to cache them.
+    Run `az login`, then use this script for a Gradle project or explicit Maven
+    coordinates. Tokens are sent only in the Authorization header and are not
+    written to output.
+
+.EXAMPLE
+    pwsh ./build/gradle/mirror-dependencies.ps1 `
+        -ProjectDir source/com.google.android.play/asset.delivery.extensions `
+        -Task build
+
+.EXAMPLE
+    pwsh ./build/gradle/mirror-dependencies.ps1 `
+        -MavenArtifact 'com.google.code.gson:gson:2.11.0'
+#>
+[CmdletBinding(DefaultParameterSetName = 'Gradle')]
+param (
+    [Parameter(Mandatory, ParameterSetName = 'Gradle')]
+    [string] $ProjectDir,
+
+    [Parameter(Mandatory, ParameterSetName = 'Gradle')]
+    [string] $Task,
+
+    [Parameter(Mandatory, ParameterSetName = 'MavenArtifact')]
+    [string[]] $MavenArtifact,
+
+    [Parameter(ParameterSetName = 'Gradle')]
+    [string] $AndroidHome = $env:ANDROID_HOME,
+
+    [Parameter(ParameterSetName = 'Gradle')]
+    [int] $MaxIterations = 15
+)
+
+$ErrorActionPreference = 'Stop'
+$feedBaseUrl = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+$azDevOpsResource = '499b84ac-1321-427f-aa17-267ca6975798'
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '../..') | Select-Object -ExpandProperty Path
+
+function Get-AzDevOpsToken {
+    $token = az account get-access-token --resource $azDevOpsResource --query accessToken -o tsv 2>$null
+    if ([string]::IsNullOrEmpty($token)) {
+        throw "Could not get an Azure DevOps access token. Run 'az login' first."
+    }
+    $token
+}
+
+function Invoke-MirrorUrls([string[]] $Urls) {
+    $token = Get-AzDevOpsToken
+    $credential = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$token"))
+    $headers = @{ Authorization = "Basic $credential" }
+    foreach ($url in $Urls | Sort-Object -Unique) {
+        $response = Invoke-WebRequest -Uri $url -Headers $headers -SkipHttpErrorCheck
+        Write-Host "$($response.StatusCode) $url"
+    }
+}
+
+Get-AzDevOpsToken | Out-Null
+
+if ($PSCmdlet.ParameterSetName -eq 'MavenArtifact') {
+    $urls = foreach ($artifact in $MavenArtifact) {
+        $parts = $artifact.Split(':', 4)
+        if ($parts.Count -lt 3) {
+            throw "Invalid Maven artifact '$artifact'. Expected group:artifact:version[:filename]."
+        }
+        $group = $parts[0].Replace('.', '/')
+        $name = $parts[1]
+        $version = $parts[2]
+        $files = if ($parts.Count -eq 4) {
+            @($parts[3])
+        } else {
+            @("$name-$version.pom", "$name-$version.jar", "$name-$version.aar", "$name-$version.module")
+        }
+        foreach ($file in $files) {
+            "$feedBaseUrl/$group/$name/$version/$file"
+        }
+    }
+    Invoke-MirrorUrls $urls
+    return
+}
+
+$project = Resolve-Path (Join-Path $repoRoot $ProjectDir) | Select-Object -ExpandProperty Path
+$wrapper = Join-Path $project $(if ($IsWindows -or $env:OS -eq 'Windows_NT') { 'gradlew.bat' } else { 'gradlew' })
+$wrapper = Resolve-Path $wrapper | Select-Object -ExpandProperty Path
+$env:RUNNINGONCI = 'true'
+if ($AndroidHome) {
+    $env:ANDROID_HOME = $AndroidHome
+}
+
+Push-Location $project
+$logs = @()
+try {
+    for ($iteration = 1; $iteration -le $MaxIterations; $iteration++) {
+        $log = Join-Path ([IO.Path]::GetTempPath()) "gradle-mirror-$PID-$iteration.log"
+        $logs += $log
+        & $wrapper $Task --no-daemon --refresh-dependencies *>&1 | Tee-Object -FilePath $log | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Gradle succeeded after $iteration iteration(s)."
+            return
+        }
+
+        $urls = Select-String -Path $log -Pattern "Could not (?:GET|HEAD) '(https://pkgs\.dev\.azure\.com/dnceng/[^']+)'" -AllMatches |
+            ForEach-Object { $_.Matches.Groups[1].Value } |
+            Sort-Object -Unique
+        if ($urls.Count -eq 0) {
+            Get-Content $log -Tail 30
+            throw "Gradle failed without any mirror URLs to seed."
+        }
+        Invoke-MirrorUrls $urls
+    }
+    throw "Gradle did not succeed after $MaxIterations iterations."
+}
+finally {
+    Pop-Location
+    Remove-Item $logs -ErrorAction SilentlyContinue
+}

--- a/source/com.google.android.material/material.extensions/build.gradle
+++ b/source/com.google.android.material/material.extensions/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     
     repositories {
-        if (System.getenv('RUNNINGONCI') == 'true') {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'
@@ -24,7 +24,7 @@ buildscript {
 
 allprojects {
     repositories {
-        if (System.getenv('RUNNINGONCI') == 'true') {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'

--- a/source/com.google.android.material/material.extensions/build.gradle
+++ b/source/com.google.android.material/material.extensions/build.gradle
@@ -3,9 +3,15 @@
 buildscript {
     
     repositories {
-        google()
-        mavenCentral()
-        
+        if (System.getenv('RUNNINGONCI') == 'true') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.12.0'
@@ -18,9 +24,15 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
-        mavenCentral()
-        
+        if (System.getenv('RUNNINGONCI') == 'true') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+        }
     }
 }
 

--- a/source/com.google.android.play/asset.delivery.extensions/build.gradle
+++ b/source/com.google.android.play/asset.delivery.extensions/build.gradle
@@ -1,8 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        google()
-        mavenCentral()
+        if (System.getenv('RUNNINGONCI') == 'true') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:8.12.0"
@@ -14,8 +21,15 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
-        mavenCentral()
+        if (System.getenv('RUNNINGONCI') == 'true') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+        }
     }
 }
 

--- a/source/com.google.android.play/asset.delivery.extensions/build.gradle
+++ b/source/com.google.android.play/asset.delivery.extensions/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        if (System.getenv('RUNNINGONCI') == 'true') {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'
@@ -21,7 +21,7 @@ buildscript {
 
 allprojects {
     repositories {
-        if (System.getenv('RUNNINGONCI') == 'true') {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'

--- a/source/com.google.android.play/core.extensions/build.gradle
+++ b/source/com.google.android.play/core.extensions/build.gradle
@@ -1,8 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        google()
-        mavenCentral()
+        if (System.getenv('RUNNINGONCI') == 'true') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:8.12.0"
@@ -14,8 +21,15 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
-        mavenCentral()
+        if (System.getenv('RUNNINGONCI') == 'true') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+        }
     }
 }
 

--- a/source/com.google.android.play/core.extensions/build.gradle
+++ b/source/com.google.android.play/core.extensions/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        if (System.getenv('RUNNINGONCI') == 'true') {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'
@@ -21,7 +21,7 @@ buildscript {
 
 allprojects {
     repositories {
-        if (System.getenv('RUNNINGONCI') == 'true') {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'

--- a/source/com.google.android.play/feature.delivery.extensions/build.gradle
+++ b/source/com.google.android.play/feature.delivery.extensions/build.gradle
@@ -1,8 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        google()
-        mavenCentral()
+        if (System.getenv('RUNNINGONCI') == 'true') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:8.12.0"
@@ -14,8 +21,15 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
-        mavenCentral()
+        if (System.getenv('RUNNINGONCI') == 'true') {
+            maven {
+                url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
+                name = 'dotnet-public-maven'
+            }
+        } else {
+            google()
+            mavenCentral()
+        }
     }
 }
 

--- a/source/com.google.android.play/feature.delivery.extensions/build.gradle
+++ b/source/com.google.android.play/feature.delivery.extensions/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        if (System.getenv('RUNNINGONCI') == 'true') {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'
@@ -21,7 +21,7 @@ buildscript {
 
 allprojects {
     repositories {
-        if (System.getenv('RUNNINGONCI') == 'true') {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
             maven {
                 url = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1'
                 name = 'dotnet-public-maven'

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/GenerationTests.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/GenerationTests.cs
@@ -10,6 +10,24 @@ namespace Xamarin.AndroidBinderator.Tests
 	public class GenerationTests : BaseTest
 	{
 		[Theory]
+		[InlineData (false, MavenRepoType.MavenCentral, "", MavenRepoType.MavenCentral, "")]
+		[InlineData (true, MavenRepoType.MavenCentral, "", MavenRepoType.Url, MavenRepositoryResolver.DotNetPublicMaven)]
+		[InlineData (true, MavenRepoType.Google, "", MavenRepoType.Google, "")]
+		[InlineData (true, MavenRepoType.Url, "https://example.com/maven", MavenRepoType.Url, "https://example.com/maven")]
+		public void MavenCentralUsesMirrorOnlyOnCI (
+			bool runningOnCI,
+			MavenRepoType type,
+			string location,
+			MavenRepoType expectedType,
+			string expectedLocation)
+		{
+			var actual = MavenRepositoryResolver.Resolve (type, location, runningOnCI);
+
+			Assert.Equal (expectedType, actual.type);
+			Assert.Equal (expectedLocation, actual.location);
+		}
+
+		[Theory]
 		[InlineData(true)]
 		[InlineData(false)]
 		public async Task ExternalsAreNotDownloadedOnlyWhenRequested(bool shouldDownload)

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
@@ -46,14 +46,14 @@ public static class MavenFactory
 	{
 		// Precendence: Artifact > TemplateSet > Config
 		if (artifact.MavenRepositoryType.HasValue)
-			return (artifact.MavenRepositoryType.Value, artifact.MavenRepositoryLocation!);
+			return MavenRepositoryResolver.Resolve (artifact.MavenRepositoryType.Value, artifact.MavenRepositoryLocation!);
 
 		var template = config.GetTemplateSet (artifact.TemplateSet);
 
 		if (template.MavenRepositoryType.HasValue)
-			return (template.MavenRepositoryType.Value, template.MavenRepositoryLocation!);
+			return MavenRepositoryResolver.Resolve (template.MavenRepositoryType.Value, template.MavenRepositoryLocation!);
 
-		return (config.MavenRepositoryType, config.MavenRepositoryLocation!);
+		return MavenRepositoryResolver.Resolve (config.MavenRepositoryType, config.MavenRepositoryLocation!);
 	}
 
 	static MavenRepository GetOrCreateRepository (MavenRepoType type, string location)

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory2.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory2.cs
@@ -71,7 +71,9 @@ public static class MavenFactory2
 		if (type == MavenRepoType.Directory)
 			throw new ArgumentException ("Directory repository type not supported");
 		else if (type == MavenRepoType.Url)
-			maven = new MavenRepository (location, location);
+			maven = new MavenRepository (
+				location,
+				location == MavenRepositoryResolver.DotNetPublicMaven ? "dotnet-public-maven" : location);
 		else if (type == MavenRepoType.MavenCentral)
 			maven = MavenRepository.Central;
 		else

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory2.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory2.cs
@@ -49,14 +49,14 @@ public static class MavenFactory2
 	{
 		// Precendence: Artifact > TemplateSet > Config
 		if (artifact.MavenRepositoryType.HasValue)
-			return (artifact.MavenRepositoryType.Value, artifact.MavenRepositoryLocation!);
+			return MavenRepositoryResolver.Resolve (artifact.MavenRepositoryType.Value, artifact.MavenRepositoryLocation!);
 
 		var template = config.GetTemplateSet (artifact.TemplateSet);
 
 		if (template.MavenRepositoryType.HasValue)
-			return (template.MavenRepositoryType.Value, template.MavenRepositoryLocation!);
+			return MavenRepositoryResolver.Resolve (template.MavenRepositoryType.Value, template.MavenRepositoryLocation!);
 
-		return (config.MavenRepositoryType, config.MavenRepositoryLocation!);
+		return MavenRepositoryResolver.Resolve (config.MavenRepositoryType, config.MavenRepositoryLocation!);
 	}
 
 	static CachedMavenRepository GetOrCreateRepository (MavenRepoType type, string location)

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenRepositoryResolver.cs
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenRepositoryResolver.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace AndroidBinderator;
+
+internal static class MavenRepositoryResolver
+{
+	public const string DotNetPublicMaven = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1";
+
+	public static (MavenRepoType type, string location) Resolve (MavenRepoType type, string location)
+		=> Resolve (type, location, string.Equals (Environment.GetEnvironmentVariable ("RUNNINGONCI"), "true", StringComparison.OrdinalIgnoreCase));
+
+	internal static (MavenRepoType type, string location) Resolve (MavenRepoType type, string location, bool runningOnCI)
+		=> runningOnCI && type == MavenRepoType.MavenCentral
+			? (MavenRepoType.Url, DotNetPublicMaven)
+			: (type, location);
+}

--- a/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -34,6 +34,10 @@
     </ItemGroup>
 
     <ItemGroup>
+      <InternalsVisibleTo Include="Xamarin.AndroidBinderator.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
       <Reference Include="Java.Interop.Tools.Maven">
         <HintPath>..\..\..\tools\Microsoft.Android.Sdk.Windows.35.0.61\tools\Java.Interop.Tools.Maven.dll</HintPath>
         <Private>True</Private>

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
@@ -22,6 +22,7 @@ namespace NativeLibraryDownloaderTests
 	{
 		public static string Configuration = "Release";
 		public static readonly string[] DEFAULT_IGNORE_PATTERNS = { "*.overridetasks", "*.tasks" };
+		const string DotNetPublicMavenGson = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-maven/maven/v1/com/google/code/gson/gson/2.11.0/gson-2.11.0.jar";
 
 		void AddCoreTargets (ProjectRootElement el)
 		{
@@ -189,10 +190,10 @@ namespace NativeLibraryDownloaderTests
 			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
 
 			prel.AddItem (
-				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
-					{ "Url", "https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar" },
+				"XamarinBuildDownload", "Gson-2.11.0", new Dictionary<string, string> {
+					{ "Url", DotNetPublicMavenGson },
 					{ "Kind", "Uncompressed" },
-					{ "ToFile", "facebook-android-sdk.aar" }
+					{ "ToFile", "gson.jar" }
 				});
 
 			AddCoreTargets (prel);
@@ -205,7 +206,7 @@ namespace NativeLibraryDownloaderTests
 			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
 			Assert.True (success);
 
-			Assert.True (File.Exists (Path.Combine (unpackDir, "FacebookAndroid-4.17.0", "facebook-android-sdk.aar")));
+			Assert.True (File.Exists (Path.Combine (unpackDir, "Gson-2.11.0", "gson.jar")));
 		}
 
 		[Fact]
@@ -218,8 +219,8 @@ namespace NativeLibraryDownloaderTests
 			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
 
 			prel.AddItem (
-				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
-					{ "Url", "https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar" },
+				"XamarinBuildDownload", "Gson-2.11.0", new Dictionary<string, string> {
+					{ "Url", DotNetPublicMavenGson },
 					{ "Kind", "Uncompressed" },
 				});
 
@@ -233,7 +234,7 @@ namespace NativeLibraryDownloaderTests
 			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
 			Assert.True (success);
 
-			Assert.True (File.Exists (Path.Combine (unpackDir, "FacebookAndroid-4.17.0", "FacebookAndroid-4.17.0.uncompressed")));
+			Assert.True (File.Exists (Path.Combine (unpackDir, "Gson-2.11.0", "Gson-2.11.0.uncompressed")));
 		}
 
 		//in google maps, the tar inside the tgz doesn't match the tgz name
@@ -421,7 +422,7 @@ namespace NativeLibraryDownloaderTests
 		[Fact]
 		public void TestDisallowUnsafeGetItemsToDownload ()
 		{
-			var itemUrl = "http://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar";
+			var itemUrl = "http://example.com/artifact.aar";
 			var zipUrl = "http://dl-ssl.google.com/android/repository/android_m2repository_r40.zip";
 
 			var engine = new ProjectCollection ();
@@ -459,7 +460,7 @@ namespace NativeLibraryDownloaderTests
 		[Fact]
 		public void TestAllowUnsafeGetItemsToDownload ()
 		{
-			var itemUrl = "http://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar";
+			var itemUrl = "http://example.com/artifact.aar";
 			var zipUrl = "http://dl-ssl.google.com/android/repository/android_m2repository_r40.zip";
 
 			var engine = new ProjectCollection ();
@@ -500,7 +501,7 @@ namespace NativeLibraryDownloaderTests
 		[Fact]
 		public void TestGetItemsToDownload ()
 		{
-			var itemUrl = "https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar";
+			var itemUrl = DotNetPublicMavenGson;
 
 			var engine = new ProjectCollection ();
 			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
@@ -533,7 +534,7 @@ namespace NativeLibraryDownloaderTests
 		[Fact]
 		public void TestDeduplicateGetItemsToDownload ()
 		{
-			var itemUrl = "https://search.maven.org/remotecontent?filepath=com/facebook/android/facebook-android-sdk/4.17.0/facebook-android-sdk-4.17.0.aar";
+			var itemUrl = DotNetPublicMavenGson;
 
 			var engine = new ProjectCollection ();
 			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);

--- a/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
+++ b/util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
@@ -432,7 +432,7 @@ namespace NativeLibraryDownloaderTests
 			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
 
 			prel.AddItem (
-				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+				"XamarinBuildDownload", "Gson-2.11.0", new Dictionary<string, string> {
 					{ "Url", itemUrl },
 					{ "Kind", "Uncompressed" },
 				});
@@ -471,7 +471,7 @@ namespace NativeLibraryDownloaderTests
 			prel.SetProperty ("XamarinBuildDownloadAllowUnsecure", "true");
 
 			prel.AddItem (
-				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+				"XamarinBuildDownload", "Gson-2.11.0", new Dictionary<string, string> {
 					{ "Url", itemUrl },
 					{ "Kind", "Uncompressed" },
 				});
@@ -510,7 +510,7 @@ namespace NativeLibraryDownloaderTests
 			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
 
 			prel.AddItem (
-				"XamarinBuildDownload", "FacebookAndroid-4.17.0", new Dictionary<string, string> {
+				"XamarinBuildDownload", "Gson-2.11.0", new Dictionary<string, string> {
 					{ "Url", itemUrl },
 					{ "Kind", "Uncompressed" },
 				});


### PR DESCRIPTION
## Summary

- route Binderator Maven Central requests through `dotnet-public-maven` when `RUNNINGONCI=true`, while preserving local repository behavior
- route all four Gradle extension builds through the mirror in CI
- update Xamarin.Build.Download network tests to use the anonymously cached Gson 2.11.0 mirror artifact instead of public Maven endpoints
- add an authenticated, token-safe helper for seeding future Gradle dependency graphs or explicit Maven coordinates

## Validation

- focused Binderator mirror-routing tests passed
- focused Xamarin.Build.Download Maven-related tests passed
- all four Gradle roots passed `gradlew help` with `RUNNINGONCI=true`
- pipeline YAML and mirror PowerShell syntax validated
- `git diff --check` passed
- all 126 configured Maven Central POMs, Android Gradle Plugin 8.12.0, and the four extension root POMs return HTTP 200 anonymously from `dotnet-public-maven`

No current Maven artifacts require one-time seeding.