### PR TITLE
[ci] Stop lint Maven Central traffic

### DIFF
--- a/source/com.google.android.material/material.extensions/app/build.gradle
+++ b/source/com.google.android.material/material.extensions/app/build.gradle
@@ -25,6 +25,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    lint {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
+            // This check bypasses Gradle repositories and contacts Maven Central directly.
+            disable 'NewerVersionAvailable'
+        }
+    }
 }
 
 dependencies {

--- a/source/com.google.android.material/material.extensions/extensions-aar/build.gradle
+++ b/source/com.google.android.material/material.extensions/extensions-aar/build.gradle
@@ -25,6 +25,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    lint {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
+            // This check bypasses Gradle repositories and contacts Maven Central directly.
+            disable 'NewerVersionAvailable'
+        }
+    }
 }
 
 dependencies {

--- a/source/com.google.android.play/asset.delivery.extensions/extensions-aar/build.gradle
+++ b/source/com.google.android.play/asset.delivery.extensions/extensions-aar/build.gradle
@@ -25,6 +25,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    lint {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
+            // This check bypasses Gradle repositories and contacts Maven Central directly.
+            disable 'NewerVersionAvailable'
+        }
+    }
 }
 
 dependencies {

--- a/source/com.google.android.play/core.extensions/extensions-aar/build.gradle
+++ b/source/com.google.android.play/core.extensions/extensions-aar/build.gradle
@@ -28,6 +28,10 @@ android {
     
     lint {
         baseline = file("lint-baseline.xml")
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
+            // This check bypasses Gradle repositories and contacts Maven Central directly.
+            disable 'NewerVersionAvailable'
+        }
     }
 }
 

--- a/source/com.google.android.play/feature.delivery.extensions/extensions-aar/build.gradle
+++ b/source/com.google.android.play/feature.delivery.extensions/extensions-aar/build.gradle
@@ -25,6 +25,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    lint {
+        if ('true'.equalsIgnoreCase(System.getenv('RUNNINGONCI'))) {
+            // This check bypasses Gradle repositories and contacts Maven Central directly.
+            disable 'NewerVersionAvailable'
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

AGP 8.12 lint's `NewerVersionAvailable` check bypasses configured Gradle repositories and contacts `repo1.maven.org` directly, leaving five Maven Central requests in every CI build.

Disable that networked advisory only when `RUNNINGONCI=true` in the five Gradle modules. Local developer builds retain the version check, while CI dependency resolution remains routed through `dotnet-public-maven`.

## Validation

- Full `build` completed for all four Gradle roots with a fresh Gradle cache
- All 2,026 Gradle dependency-resolver requests targeted `pkgs.dev.azure.com`
- Java debug traces contained zero `repo1.maven.org` requests
- An isolated local run with `RUNNINGONCI` unset still made the expected lint metadata requests