### PR TITLE
[ci] Route API diff through dotnet-public

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,7 +43,7 @@ jobs:
       uses: ./.github/workflows/log-disk-space
 
     - name: Install Android workload
-      run: dotnet workload install android
+      run: dotnet workload install android --configfile NuGet.config
 
     - name: Log disk space (after Android workload)
       uses: ./.github/workflows/log-disk-space

--- a/build/ci/setup-environment.yml
+++ b/build/ci/setup-environment.yml
@@ -26,7 +26,7 @@ steps:
     ignoreLASTEXITCODE: true
 
   - pwsh: |    
-      dotnet workload install maui-android android --verbosity diag --source $(dotnetWorkloadSource)
+      dotnet workload install maui-android android --verbosity diag --configfile NuGet.config
       if ($LASTEXITCODE -ne 0) {
           Write-Host "##vso[task.logissue type=error]Failed to install workloads."
           Write-Host "##vso[task.complete result=Failed;]"

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -21,7 +21,6 @@ variables:
   # Tool variables
   dotnetVersion: '10.x'                                                                 # .NET version to install on agent
   dotnetFrameworkVersion: 9                                                             # The number to use for TF (eg: netX.0-android)
-  dotnetWorkloadSource: 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json' # NuGet source for workloads
 
   # Standard test variables
   standardTestProject: tests/allpackages/AllPackagesTests.csproj                                                      # Standard tests project file

--- a/nuget-diff.cake
+++ b/nuget-diff.cake
@@ -5,6 +5,13 @@ var ROOT_DIR = MakeAbsolute((DirectoryPath)Argument("root", "."));
 var ARTIFACTS_DIR = MakeAbsolute((DirectoryPath)Argument("artifacts", ROOT_DIR.Combine("output").FullPath));
 var CACHE_DIR = MakeAbsolute((DirectoryPath)Argument("cache", ROOT_DIR.Combine("externals/api-diff").FullPath));
 var OUTPUT_DIR = MakeAbsolute((DirectoryPath)Argument("output", ROOT_DIR.Combine("output/api-diff").FullPath));
+var NUGET_SOURCE = XmlPeek(
+	ROOT_DIR.CombineWithFilePath("NuGet.config"),
+	"/configuration/packageSources/add[@key='dotnet-public']/@value");
+
+if (string.IsNullOrWhiteSpace(NUGET_SOURCE)) {
+	throw new Exception("The dotnet-public package source was not found in NuGet.config.");
+}
 
 
 // SECTION: Main Script
@@ -44,6 +51,7 @@ if (!nupkgs.Any()) {
 				.Append("--group-ids")
 				.Append("--ignore-unchanged")
 				.Append("--compare-nuget-structure")
+				.AppendSwitch("--source", "=", NUGET_SOURCE)
 				.AppendSwitchQuoted("--output", OUTPUT_DIR.FullPath)
 				.AppendSwitchQuoted("--cache", CACHE_DIR.Combine("package-cache").FullPath)
 		});


### PR DESCRIPTION
The API diff task performs package lookup independently of normal NuGet restore, causing direct traffic to NuGet.org despite the repository-level configuration.

This change reads the canonical `dotnet-public` source from `NuGet.config` and passes it explicitly to `api-tools nuget-diff`. Workload installation paths now also use the root configuration, and the duplicated workload source variable has been removed.

Validation:
- Ran `nuget-diff.cake` against a real mirrored package and confirmed the generated command uses the `dotnet-public` source.
- Parsed the changed YAML files successfully.
- Ran `git diff --check`.