### PR TITLE
[ci] Apply CFSClean environment settings

### DIFF
--- a/build/ci/build-and-test.yml
+++ b/build/ci/build-and-test.yml
@@ -16,7 +16,6 @@ steps:
     displayName: 'Build packages'
     env:
       JavaSdkDirectory: $(JAVA_HOME)
-      RUNNINGONCI: true
       RepositoryCommit: $(Build.SourceVersion)
       RepositoryBranch: $(Build.SourceBranchName)
       RepositoryUrl: $(Build.Repository.Uri)

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -7,6 +7,12 @@ variables:
   mainBranchName: main                                                                  # Name of Git "main" branch
   configuration: Release                                                                # Build configuration: 'Debug', 'Release'
   verbosity: 'normal'                                                                   # Build verbosity: 'minimal', 'normal', 'diagnostic'
+  DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT: true
+  DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: true
+  DOTNET_SDK_VULNERABILITY_CHECK_DISABLE: true
+  NuGetAudit: false
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  RUNNINGONCI: true
 
   # Reporting variables
   areaPath: DevDiv\VS Client - Runtime SDKs\Android                                     # AzDo area path to log any issues

--- a/tests/allpackages/TestAllIndividualPackages.cs
+++ b/tests/allpackages/TestAllIndividualPackages.cs
@@ -167,7 +167,7 @@ public class TestAllIndividualPackages
 		Directory.CreateDirectory (case_dir);
 
 		// Create new dotnet project
-		await RunAndAssertSuccess ($"new {template}", case_dir);
+		await RunAndAssertSuccess ($"new {template} --no-restore", case_dir);
 
 		// - Replace <SupportedOSPlatformVersion> with the maximum version some packages require
 		// - Remove the target frameworks that are not 'android'

--- a/tests/extended/TestAllIndividualPackages.cs
+++ b/tests/extended/TestAllIndividualPackages.cs
@@ -87,7 +87,7 @@ public class TestAllIndividualPackages
 		Directory.CreateDirectory (case_dir);
 
 		// Create new dotnet project
-		await RunAndAssertSuccess ($"new {template}", case_dir);
+		await RunAndAssertSuccess ($"new {template} --no-restore", case_dir);
 
 		// - Replace <SupportedOSPlatformVersion> with the maximum version some packages require
 		// - Remove the target frameworks that are not 'android'


### PR DESCRIPTION
Azure builds can make unnecessary public network requests for certificate revocation, SDK update checks, vulnerability auditing, telemetry, and implicit template restores. Centralize the relevant CI settings to keep these operations compatible with CFSClean network isolation.

- Apply the .NET revocation, workload notification, vulnerability audit, NuGet audit, and telemetry settings to both Azure pipeline entry points through the shared variables template.
- Set the repository-consumed `RUNNINGONCI` marker globally and remove its duplicate step-level definition so Maven and Gradle paths consistently use the configured dnceng mirrors.
- Add `--no-restore` to template creation because the generated projects are modified before their later build and restore.

Validation:
- Built `tests/allpackages/AllPackagesTests.csproj` and `tests/extended/ExtendedTests.csproj`.
- Parsed both pipeline entry points and the changed shared YAML templates.
- Confirmed `git diff --check` passes.