### PR TITLE
[ci] Enable BAR publishing for real-signed builds

### DIFF
--- a/build/ci/stage-publish-signed-artifacts.yml
+++ b/build/ci/stage-publish-signed-artifacts.yml
@@ -12,7 +12,7 @@ stages:
 - stage: publish_signed_packages
   displayName: Publish Signed Packages
   dependsOn: sign_artifacts
-  condition: and(succeeded(), or(and(eq('${{ parameters.runValidation }}', 'true'), eq(variables['Build.Reason'], 'Manual'), ne('${{ parameters.validationSignedBuildId }}', '0')), and(eq(variables['barPublishingEnabled'], 'true'), or(and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'Schedule')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')), ne(variables['Build.Reason'], 'PullRequest'))))
+  condition: and(succeeded(), or(and(eq('${{ parameters.runValidation }}', 'true'), eq(variables['Build.Reason'], 'Manual'), ne('${{ parameters.validationSignedBuildId }}', '0')), and(or(and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'Schedule')), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')), ne(variables['Build.Reason'], 'PullRequest'))))
   lockBehavior: sequential
 
   jobs:

--- a/build/ci/stage-publish-signed-artifacts.yml
+++ b/build/ci/stage-publish-signed-artifacts.yml
@@ -217,7 +217,6 @@ stages:
                   -PublishingInfraVersion 3
                   -AzdoToken '$(System.AccessToken)'
                   -WaitPublishingFinish true
-                  -RequireDefaultChannels true
                   -SkipAssetsPublishing false
               env:
                 NUGET_CONFIG: $(System.DefaultWorkingDirectory)\build\publishing\NuGet.config

--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -45,9 +45,6 @@ variables:
   # Signing settings
   TeamName: .NET MAUI
 
-  # Signed package publishing remains disabled until the Azure DevOps environment
-  # and service connection setup in docs/publishing-signed-packages.md is complete.
-  barPublishingEnabled: 'false'
   barTargetFeed: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json
   barFeedQueryConcurrency: '8'
   barFeedQueryAttempts: '4'

--- a/docs/publishing-signed-packages.md
+++ b/docs/publishing-signed-packages.md
@@ -10,7 +10,8 @@ Publishing requires the following external setup:
 
 1. Authorize the AndroidX pipeline to use the `Darc: Maestro Production` service connection.
 2. Add an **Exclusive lock** check to that service connection. The stage sets `lockBehavior: sequential`, so the feed check, BAR registration, and promotion remain in one serialized critical section.
-3. Configure the repository's `main` default channel in Darc to the intended public .NET 10 channel, and confirm that channel maps shipping `Package` assets to `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json`. Publishing uses Arcade's vendored `publish-using-darc.ps1` with `--default-channels-required`, so it fails safely when no default channel is configured.
+3. Configure the repository's `main` default channel in Darc to the intended public .NET 10 channel, and confirm that channel maps shipping `Package` assets to `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json`. Publishing uses Arcade's vendored `publish-using-darc.ps1` to publish through configured default channels. Until a default channel is configured, builds remain registered in BAR without publishing packages.
+
 The public `dotnet10` feed currently permits anonymous reads. If that policy changes, supply a read token through a secret environment variable and pass its name with `--feed-token-env`; the tool never accepts a token value on its command line.
 
 The stage uses the same real-sign condition as `build/ci/stage-sign-artifacts.yml`: non-PR `release/*` builds and non-scheduled `main` builds. PRs, scheduled builds, public validation, and all test-signed artifacts are excluded.

--- a/docs/publishing-signed-packages.md
+++ b/docs/publishing-signed-packages.md
@@ -10,7 +10,7 @@ Publishing requires the following external setup:
 
 1. Authorize the AndroidX pipeline to use the `Darc: Maestro Production` service connection.
 2. Add an **Exclusive lock** check to that service connection. The stage sets `lockBehavior: sequential`, so the feed check, BAR registration, and promotion remain in one serialized critical section.
-3. Configure the repository's `main` default channel in Darc to the intended public .NET 10 channel, and confirm that channel maps shipping `Package` assets to `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json`. Publishing uses Arcade's vendored `publish-using-darc.ps1` to publish through configured default channels. Until a default channel is configured, builds remain registered in BAR without publishing packages.
+3. For each branch intended to publish (`main` and applicable `release/*` branches), configure its Darc default channel to the intended public .NET 10 channel, and confirm that channel maps shipping `Package` assets to `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json`. Publishing uses Arcade's vendored `publish-using-darc.ps1` to publish through configured default channels. Until a branch's default channel is configured, its builds remain registered in BAR without publishing packages.
 
 The public `dotnet10` feed currently permits anonymous reads. If that policy changes, supply a read token through a secret environment variable and pass its name with `--feed-token-env`; the tool never accepts a token value on its command line.
 

--- a/docs/publishing-signed-packages.md
+++ b/docs/publishing-signed-packages.md
@@ -6,13 +6,11 @@ The manifest uses Arcade's `PackageArtifactModel` with `Category=Package` and `N
 
 ## One-time Azure DevOps setup
 
-Publishing is intentionally disabled by `barPublishingEnabled: false` until all setup below is complete:
+Publishing requires the following external setup:
 
 1. Authorize the AndroidX pipeline to use the `Darc: Maestro Production` service connection.
 2. Add an **Exclusive lock** check to that service connection. The stage sets `lockBehavior: sequential`, so the feed check, BAR registration, and promotion remain in one serialized critical section.
 3. Configure the repository's `main` default channel in Darc to the intended public .NET 10 channel, and confirm that channel maps shipping `Package` assets to `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json`. Publishing uses Arcade's vendored `publish-using-darc.ps1` with `--default-channels-required`, so it fails safely when no default channel is configured.
-4. Set `barPublishingEnabled` to `true` in `build/ci/variables.yml`.
-
 The public `dotnet10` feed currently permits anonymous reads. If that policy changes, supply a read token through a secret environment variable and pass its name with `--feed-token-env`; the tool never accepts a token value on its command line.
 
 The stage uses the same real-sign condition as `build/ci/stage-sign-artifacts.yml`: non-PR `release/*` builds and non-scheduled `main` builds. PRs, scheduled builds, public validation, and all test-signed artifacts are excluded.

--- a/docs/publishing-signed-packages.md
+++ b/docs/publishing-signed-packages.md
@@ -10,7 +10,7 @@ Publishing requires the following external setup:
 
 1. Authorize the AndroidX pipeline to use the `Darc: Maestro Production` service connection.
 2. Add an **Exclusive lock** check to that service connection. The stage sets `lockBehavior: sequential`, so the feed check, BAR registration, and promotion remain in one serialized critical section.
-3. For each branch intended to publish (`main` and applicable `release/*` branches), configure its Darc default channel to the intended public .NET 10 channel, and confirm that channel maps shipping `Package` assets to `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json`. Publishing uses Arcade's vendored `publish-using-darc.ps1` to publish through configured default channels. Until a branch's default channel is configured, its builds remain registered in BAR without publishing packages.
+3. Configure the repository's `main` default channel in Darc to the intended public .NET 10 channel, and confirm that channel maps shipping `Package` assets to `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json`. Publishing uses Arcade's vendored `publish-using-darc.ps1` to publish through configured default channels. Until a default channel is configured, builds remain registered in BAR without publishing packages.
 
 The public `dotnet10` feed currently permits anonymous reads. If that policy changes, supply a read token through a secret environment variable and pass its name with `--feed-token-env`; the tool never accepts a token value on its command line.
 


### PR DESCRIPTION
## Summary
- remove the stale `barPublishingEnabled` gate and variable
- run `publish_signed_packages` automatically under the same real-sign condition as signing
- retain manual BAR validation and external setup documentation

## Validation
- parsed the changed YAML files with PyYAML
- verified the BAR branch/reason condition matrix (9 cases)
- `dotnet test build\publishing\SignedPackagePublisher.Tests\SignedPackagePublisher.Tests.csproj --configuration Release --nologo` (18 passed)