### PR TITLE
[build] Serialize pose detection projects

### DIFF
--- a/source/_PackageLevelCustomizations.cshtml
+++ b/source/_PackageLevelCustomizations.cshtml
@@ -1,12 +1,33 @@
 @model AndroidBinderator.BindingProjectModel
 @using System
+@using System.Collections.Generic
 @using System.Linq
 
 @* 
    Ideally we don't want to maintain any package-specific customizations,
    but we don't always have a better option. 
 *@
-  
+
+@{
+  // Build-order-only edges for projects that contend for shared generated outputs.
+  var buildOrderProjectReferences = new Dictionary<string, string[]> {
+    ["Xamarin.Google.MLKit.PoseDetection"] = new [] {
+      "com.google.mlkit.pose-detection-accurate",
+    },
+  };
+}
+
+@if (buildOrderProjectReferences.TryGetValue(Model.NuGetPackageId, out var buildOrderDependencies))
+{
+  <ItemGroup>
+  @foreach (var dependency in buildOrderDependencies) {
+    <ProjectReference Include="..\..\generated\@(dependency)\@(dependency).csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  }
+  </ItemGroup>
+}
+
 @if(Model.NuGetPackageId == "Xamarin.Google.Guava") {
   <ItemGroup>
     <!-- Reference a version of ListenableFuture that does not contain 'listenablefuture.jar' -->


### PR DESCRIPTION
## Changes

- Add a reusable mapping for build-order-only project references.
- Serialize `pose-detection` after `pose-detection-accurate` so they do not concurrently consume the shared `pose-detection-common` AAR.
- Use `ReferenceOutputAssembly="false"` and `PrivateAssets="all"` so the ordering edge does not affect compilation or NuGet dependencies.

## Validation

- Regenerated projects with `dotnet cake build.cake --target=binderate --verbosity=minimal`.
- Built the pose-detection graph with two MSBuild nodes.
- Packed `Xamarin.Google.MLKit.PoseDetection` and confirmed `PoseDetection.Accurate` is absent from the generated `.nuspec` dependencies.