### PR TITLE
[ci] Keep NuGet revocation checks offline

### DIFF
--- a/build/ci/variables.yml
+++ b/build/ci/variables.yml
@@ -8,6 +8,7 @@ variables:
   configuration: Release                                                                # Build configuration: 'Debug', 'Release'
   verbosity: 'normal'                                                                   # Build verbosity: 'minimal', 'normal', 'diagnostic'
   DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT: true
+  NUGET_CERT_REVOCATION_MODE: offline
   DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: true
   DOTNET_SDK_VULNERABILITY_CHECK_DISABLE: true
   NuGetAudit: false


### PR DESCRIPTION
## Summary

- set `NUGET_CERT_REVOCATION_MODE=offline` for Azure pipeline jobs
- prevent NuGet package-signing verification from contacting public OCSP responders in CFS network-isolated builds
- preserve the existing approved `dotnet-public` NuGet source and avoid adding network allowlists

## Investigation

AndroidX pipeline 12322 network-isolation telemetry showed `ocsp.sectigo.com`, `ocsp.comodoca.com`, and `ocsp.entrust.net` requests from `dotnet.exe` in the Windows build job. NuGet.org and Maven Central package traffic is already routed through repository-standard Azure Artifacts feeds on `main`.

## References

- [NuGet warning NU3028](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3028) recommends `NUGET_CERT_REVOCATION_MODE=offline` for CI/build machines with restricted internet access.
- [NuGet environment variables](https://learn.microsoft.com/nuget/reference/cli-reference/cli-ref-environment-variables#nuget_cert_revocation_mode)
- [NuGet.Client implementation](https://github.com/NuGet/NuGet.Client/blob/e8f96a017b65bdda6c740dd007b182ca5d8f3d21/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs)
- [NuGet.Client tests](https://github.com/NuGet/NuGet.Client/blob/e8f96a017b65bdda6c740dd007b182ca5d8f3d21/test/NuGet.Core.Tests/NuGet.Packaging.Test/SigningTests/SignedPackageVerifierSettingsTests.cs)

## Validation

- `dotnet tool restore --configfile NuGet.config` with `NUGET_CERT_REVOCATION_MODE=offline`
- `git diff --check`