### PR TITLE
Apply CFSClean network isolation to AndroidX pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,8 @@ extends:
       sourceRepositoriesToScan:
         exclude:
         - repository: yaml-templates
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     pool:
       name: AzurePipelines-EO
       image: 1ESPT-Windows2022


### PR DESCRIPTION
## Summary

- configure the shared 1ES pipeline entry point with `networkIsolationPolicy: Permissive,CFSClean`
- retain permissive connectivity while enabling the required Centralized Feed Service policy
- preserve the pipeline-required `CFSClean2` and `CFSClean3` policies without adding public-feed allowlists

## Rationale

This applies the required SFI/CFS network-isolation posture at `extends.parameters.settings`, the single shared placement used by both the official production template and unofficial PR template selection. Keeping the setting at the root avoids duplicating it across jobs or stages.

The separate `azure-pipelines-public.yml` entry point does not extend a 1ES pipeline template, so it is not an applicable network-isolation policy surface.

## Validation

Azure DevOps AndroidX validation:

- Run [20260902.2 (15183877)](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15183877): expanded template logs show `networkIsolationMode: Enforce` with `policyName: Permissive,CFSClean` on generated jobs.
- The `Start Network Isolation` log invoked `Enforce -Policies Permissive,CFSClean`, selected `Permissive` and `CFSClean` from pipeline arguments, retained `CFSClean2` and `CFSClean3` from `PerPipelineRequiredConfig`, and ended with `Successfully completed 'Enforce' command.`
- Java 21, .NET workloads, and Android SDK/package acquisition all succeeded under isolation. The first package-generation attempt later encountered a transient HTTP 429 after resolving hundreds of Maven artifacts; it was not a network-isolation denial.
- Retry [20260902.3 (15183997)](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15183997) again passed network-isolation startup and all dependency installation/resolution phases and proceeded into the generated package compile.

Local YAML diff validation: `git diff --check`.