### PR TITLE
[build] serialize Windows library builds

### DIFF
--- a/build/cake/build-and-package.cake
+++ b/build/cake/build-and-package.cake
@@ -31,10 +31,9 @@ Task ("libs")
         .EnableBinaryLogger ($"./output/libs.{CONFIGURATION}.binlog")
         .WithProperty("Verbosity", VERBOSITY.ToString ());
 
-    // Limit parallelism on Windows to reduce file locking issues during parallel builds
-    // This helps prevent race conditions when multiple projects access shared .aar files
+    // Serialize Windows project builds because dependent bindings access shared .aar files.
     if (IsRunningOnWindows ())
-        settings = settings.SetMaxCpuCount(2);
+        settings = settings.SetMaxCpuCount(1);
 
     settings.NodeReuse = false;
 


### PR DESCRIPTION
Windows package builds can run bindings that access the same generated AAR concurrently. The two-node limit still permits that race, producing intermittent XARLP7024 file-lock failures before signing and BAR registration.

Serialize the Windows AndroidX solution build with one MSBuild node while leaving non-Windows build parallelism unchanged.

Reference failures:
- [20260901.2 / 15168507](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15168507): corrupt Maven archive during Binderator extraction.
- [20260902.4 / 15188927](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15188927): XARLP7024 lock on `Xamarin.Google.MLKit.PoseDetection.Common.aar`.
- [20260908.2 / 15242700](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15242700): same XARLP7024 shared-AAR lock race.